### PR TITLE
Release v0.2.1: wallet seed API + Docker mining manual

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: "0.2.0"
+  VERSION: "0.2.1"
 
 jobs:
   build-linux-amd64:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean build-rust build-go test run install deploy release
 
-VERSION := 0.2.0
+VERSION := 0.2.1
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m)
 ifeq ($(ARCH),x86_64)

--- a/api_openapi.json
+++ b/api_openapi.json
@@ -635,6 +635,86 @@
         }
       }
     },
+    "/api/wallet/seed": {
+      "post": {
+        "operationId": "getWalletSeed",
+        "tags": ["Wallet"],
+        "summary": "Wallet recovery seed",
+        "description": "Returns the wallet's 12-word BIP39 recovery phrase. Requires Bearer token and wallet password confirmation. Response includes Cache-Control: no-store.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["password"],
+                "properties": {
+                  "password": {
+                    "type": "string",
+                    "description": "Wallet password"
+                  }
+                }
+              },
+              "example": {
+                "password": "my-wallet-passphrase"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Recovery seed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mnemonic": { "type": "string" },
+                    "words": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  }
+                },
+                "example": {
+                  "mnemonic": "abandon ability able about above absent absorb abstract absurd abuse access accident",
+                  "words": ["abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract", "absurd", "abuse", "access", "accident"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON body",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" },
+                "example": { "error": "invalid JSON body" }
+              }
+            }
+          },
+          "401": {
+            "description": "Incorrect password or missing Bearer token",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" },
+                "example": { "error": "incorrect password" }
+              }
+            }
+          },
+          "403": { "$ref": "#/components/responses/WalletLocked" },
+          "404": {
+            "description": "No recovery seed available",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" },
+                "example": { "error": "no recovery seed available" }
+              }
+            }
+          },
+          "503": { "$ref": "#/components/responses/NoWallet" }
+        }
+      }
+    },
     "/api/mining": {
       "get": {
         "operationId": "getMiningStatus",

--- a/api_openapi.json
+++ b/api_openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Blocknet Daemon API",
     "description": "Authenticated JSON API for the Blocknet privacy blockchain daemon. All private endpoints require Bearer token authentication via a cookie file (`<dataDir>/api.cookie`) written on daemon startup. Public routes (GET-only blockchain queries) are also served unauthenticated when using `--explorer` mode.",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "license": {
       "name": "MIT"
     }

--- a/api_routes.go
+++ b/api_routes.go
@@ -23,6 +23,7 @@ func (s *APIServer) registerPrivateRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/wallet/send", s.handleSend)
 	mux.HandleFunc("POST /api/wallet/lock", s.handleLock)
 	mux.HandleFunc("POST /api/wallet/unlock", s.handleUnlock)
+	mux.HandleFunc("POST /api/wallet/seed", s.handleSeed)
 
 	// Mining
 	mux.HandleFunc("GET /api/mining", s.handleMiningStatus)

--- a/crypto-rs/Cargo.toml
+++ b/crypto-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -5,10 +5,5 @@
 # Use a strong password - this encrypts your wallet
 BLOCKNET_WALLET_PASSWORD=your-secure-password-here
 
-# Auto-start mining when container starts
-# Set to "true" to enable
-BLOCKNET_AUTO_MINE=false
-
-# Number of mining threads (each uses ~2GB RAM)
-# Make sure you have enough memory!
-BLOCKNET_MINE_THREADS=1
+# Mining is started manually via the API when desired (see README.md).
+# No auto-mining settings are required.

--- a/docker/README.md
+++ b/docker/README.md
@@ -62,12 +62,29 @@ curl -X POST http://localhost:8332/api/mining/threads \
   -d '{"threads": 2}'
 ```
 
-### Auto-mine on startup:
+### Mining
+
+Mining is **not** started automatically in Docker.
+
+Use the API to start mining when desired:
 
 ```bash
-# In .env:
-BLOCKNET_AUTO_MINE=true
-BLOCKNET_MINE_THREADS=1
+# Get auth token
+TOKEN=$(docker exec blocknet-node cat /data/api.cookie)
+
+# Start mining
+curl -X POST http://localhost:8332/api/mining/start \
+  -H "Authorization: Bearer $TOKEN"
+
+# Check miner status
+curl http://localhost:8332/api/mining \
+  -H "Authorization: Bearer $TOKEN"
+
+# Set threads (each needs 2GB RAM)
+curl -X POST http://localhost:8332/api/mining/threads \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"threads": 2}'
 ```
 
 ## Auto-Updates

--- a/docker/README.md
+++ b/docker/README.md
@@ -142,13 +142,15 @@ docker run --rm -v blocknet-wallet:/wallet -v $(pwd):/backup alpine \
 
 ## Resource Requirements
 
+`docker-compose.yml` does **not** set hard memory limits by default.
+
 | Component | RAM | CPU | Disk |
 |-----------|-----|-----|------|
 | Node only | 512MB | 1 core | 10GB+ |
 | + 1 miner thread | 2.5GB | 1 core | - |
 | + 2 miner threads | 4.5GB | 2 cores | - |
 
-Mining uses Argon2id with 2GB memory per thread for ASIC resistance.
+Mining uses Argon2id with ~2GB memory per thread for ASIC resistance.
 
 ## Troubleshooting
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,15 +31,8 @@ services:
       - blocknet-data:/data
       - blocknet-wallet:/wallet
     
-    # Resource limits (adjust based on mining threads)
-    # Each mining thread needs ~2GB RAM
-    deploy:
-      resources:
-        limits:
-          memory: 18G
-        reservations:
-          memory: 4G
-    
+    # No resource limits by default.
+    # If you start mining manually via the API, ensure the host has ~2GB RAM per mining thread.
     # Logging
     logging:
       driver: "json-file"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,8 +18,6 @@ services:
       - BLOCKNET_API_ADDR=0.0.0.0:8332
       - BLOCKNET_EXPLORER_ADDR=:8080
       - BLOCKNET_WALLET_PASSWORD=${BLOCKNET_WALLET_PASSWORD:-changeme}
-      - BLOCKNET_AUTO_MINE=${BLOCKNET_AUTO_MINE:-false}
-      - BLOCKNET_MINE_THREADS=${BLOCKNET_MINE_THREADS:-1}
       - BLOCKNET_SEED_MODE=false
     
     # Port mappings
@@ -38,9 +36,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          memory: 18G
         reservations:
-          memory: 2G
+          memory: 4G
     
     # Logging
     logging:

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"blocknet/wallet"
 )
 
-const Version = "0.2.0"
+const Version = "0.2.1"
 
 func main() {
 	// Parse command line flags


### PR DESCRIPTION
Changes:
- Add authenticated `POST /api/wallet/seed` to return the wallet recovery mnemonic (password required; sets `Cache-Control: no-store`).
- Docker: remove auto-mining on container startup (mining is manual via API).
- Bump version to `0.2.1` (main, OpenAPI spec, Makefile, Cargo, and release workflow) to prepare for a `v0.2.1` tag-based GitHub release build.

Testing:
- `go test ./...`