### PR TITLE
wallet: fix incorrect balances by aligning stealth output derivation + commitment verification

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -547,13 +547,17 @@ func (s *APIServer) createTxBuilder() *wallet.Builder {
 			txID, _ := tx.TxID()
 			return txID
 		},
-		DeriveStealthAddress: func(spendPub, viewPub [32]byte) (txPriv, txPub, oneTimePub [32]byte, err error) {
-			output, err := DeriveStealthAddress(spendPub, viewPub)
+		GenerateStealthTxKeypair: func() (txPriv, txPub [32]byte, err error) {
+			kp, err := GenerateStealthTxKeypair()
 			if err != nil {
-				return txPriv, txPub, oneTimePub, err
+				return txPriv, txPub, err
 			}
-			return output.TxPrivKey, output.TxPubKey, output.OnetimePubKey, nil
+			return kp.TxPrivKey, kp.TxPubKey, nil
 		},
+		DeriveStealthOnetimePubKey: func(spendPub, viewPub, txPriv [32]byte) (oneTimePub [32]byte, err error) {
+			return DeriveStealthOnetimePubKey(spendPub, viewPub, txPriv)
+		},
+		DeriveStealthSecretSender: DeriveStealthSecretSender,
 		BlindingAdd: BlindingAdd,
 		BlindingSub: BlindingSub,
 		RingSize:    RingSize,

--- a/crypto-rs/blocknet_crypto.h
+++ b/crypto-rs/blocknet_crypto.h
@@ -148,6 +148,26 @@ int32_t blocknet_sha256(
 //   [96..128] view public key
 int32_t blocknet_stealth_keygen(uint8_t* output);
 
+// Generate a tx keypair (sender side)
+// tx_privkey_out: 32-byte buffer for transaction private key
+// tx_pubkey_out: 32-byte buffer for transaction public key (include in tx)
+int32_t blocknet_stealth_tx_keygen(
+    uint8_t* tx_privkey_out,
+    uint8_t* tx_pubkey_out
+);
+
+// Derive one-time stealth public key using a provided tx private key (sender side)
+// spend_pubkey: receiver's 32-byte spend public key
+// view_pubkey: receiver's 32-byte view public key
+// tx_privkey: 32-byte transaction private key
+// onetime_pubkey_out: 32-byte buffer for one-time address
+int32_t blocknet_stealth_derive_onetime_pubkey(
+    const uint8_t* spend_pubkey,
+    const uint8_t* view_pubkey,
+    const uint8_t* tx_privkey,
+    uint8_t* onetime_pubkey_out
+);
+
 // Derive one-time stealth address (sender side)
 // spend_pubkey: receiver's 32-byte spend public key
 // view_pubkey: receiver's 32-byte view public key

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -388,10 +388,19 @@ func (w *Wallet) MatureOutputs(currentHeight uint64) []*OwnedOutput {
 	return outputs
 }
 
-// AddOutput adds a newly discovered output
+// AddOutput adds a newly discovered output.
+// Dedupes by (txid, output_index) so rescans or repeated block notifications
+// don't inflate balances.
 func (w *Wallet) AddOutput(out *OwnedOutput) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+
+	for _, existing := range w.data.Outputs {
+		if existing.TxID == out.TxID && existing.OutputIndex == out.OutputIndex {
+			return
+		}
+	}
+
 	w.data.Outputs = append(w.data.Outputs, out)
 }
 


### PR DESCRIPTION
This PR fixes a critical wallet accounting issue where outputs can be detected as belonging to the wallet (stealth match) but the decrypted amount is incorrect (effectively random), leading to wildly incorrect spendable/pending balances.

Summary
- Ensures all outputs in a transaction share the same stealth tx public key (R) so receiver-side scanning and secret derivation are consistent.
- Aligns sender-side construction with receiver-side scanning for deriving per-output blindings/amount masks.
- Adds scanner-side commitment verification so outputs are only recorded when the decrypted (amount, blinding) actually reopens the on-chain Pedersen commitment.
- Deduplicates outputs by (txid, output_index) to prevent double-counting on rescans/replays.

Root causes
1) Multi-output tx construction could generate multiple stealth tx keypairs (r,R) across outputs, but only one TxPublicKey is stored in the tx. Outputs derived from a different (r,R) become undecryptable/unspendable and/or decode garbage amounts during scanning.
2) Amount decoding lacked a commitment check, so any mismatch in the decryption path directly polluted wallet balances.

Detailed changes
- crypto-rs/src/stealth.rs
  - Add `blocknet_stealth_tx_keygen` to generate a tx keypair (r,R).
  - Add `blocknet_stealth_derive_onetime_pubkey` to derive a one-time pubkey using a provided tx privkey r (so a single tx keypair can be reused across outputs).
- crypto-rs/blocknet_crypto.h
  - Declare the two new stealth FFI exports.
- crypto.go
  - Expose Go wrappers `GenerateStealthTxKeypair` and `DeriveStealthOnetimePubKey`.
- wallet/builder.go
  - Generate exactly one stealth tx keypair per transaction and reuse it for all outputs.
  - Derive per-output blindings deterministically from the stealth shared secret so recipients can decrypt amounts consistently.
- wallet/scanner.go
  - Add optional commitment verification: compute commitment(amount, blinding) and require it matches the output commitment before recording the output.
- wallet/wallet.go
  - Deduplicate outputs by (txid, output_index) to avoid balance inflation during rescans/replays.
- cli.go + api_handlers.go
  - Wire new callbacks into builder/scanner configuration.

Consensus / chain safety
- No changes to block/tx validation rules.
- No changes to transaction serialization, SigningHash(), or TxID() (TxID remains sha3(JSON(tx))).
- Existing transaction hashes remain unchanged.

Testing
- `make all`
- `go test ./...`
- `./blocknet --test`

Notes for operators
- If a wallet already contains corrupted outputs from earlier buggy decoding, the scanner-side commitment verification prevents *new* corrupted entries; a clean recovery/rescan may still be needed to correct existing wallet state.