### PR TITLE
Handle orphaned blocks and reorgs more gracefully

### DIFF
--- a/daemon_reorg_mempool_test.go
+++ b/daemon_reorg_mempool_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestProcessBlockData_ReorgRemovesTxsFromAllConnectedBlocks(t *testing.T) {
+	baseDir := t.TempDir()
+	local := mustNewChain(t, filepath.Join(baseDir, "local"))
+	remote := mustNewChain(t, filepath.Join(baseDir, "remote"))
+
+	genesis, err := GetGenesisBlock()
+	if err != nil {
+		t.Fatalf("failed to create genesis: %v", err)
+	}
+	if err := local.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add local genesis: %v", err)
+	}
+	if err := remote.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add remote genesis: %v", err)
+	}
+
+	// Shared block at height 1.
+	commonTs := genesis.Header.Timestamp + BlockIntervalSec
+	common1 := syntheticBlock(1, genesis.Hash(), commonTs, MinDifficulty)
+	if err := local.AddBlock(cloneBlock(common1)); err != nil {
+		t.Fatalf("failed to add local shared block: %v", err)
+	}
+	if err := remote.AddBlock(cloneBlock(common1)); err != nil {
+		t.Fatalf("failed to add remote shared block: %v", err)
+	}
+
+	// Local chain extends to height 4 at low work.
+	localTipHash := common1.Hash()
+	localTs := commonTs
+	for h := uint64(2); h <= 4; h++ {
+		localTs += BlockIntervalSec
+		block := syntheticBlock(h, localTipHash, localTs, MinDifficulty)
+		if err := local.AddBlock(block); err != nil {
+			t.Fatalf("failed to add local block %d: %v", h, err)
+		}
+		localTipHash = block.Hash()
+	}
+
+	// Remote fork has higher work and includes trackedTx at height 2.
+	trackedTx := &Transaction{
+		Version: 1,
+		Outputs: []TxOutput{{}},
+		Fee:     10_000,
+	}
+	trackedID, err := trackedTx.TxID()
+	if err != nil {
+		t.Fatalf("failed to compute tx id: %v", err)
+	}
+
+	remoteTipHash := common1.Hash()
+	remoteTs := commonTs + BlockIntervalSec
+	r2 := syntheticBlock(2, remoteTipHash, remoteTs, MinDifficulty*3)
+	r2.Transactions = []*Transaction{trackedTx}
+	if err := remote.AddBlock(r2); err != nil {
+		t.Fatalf("failed to add remote block 2: %v", err)
+	}
+	remoteTipHash = r2.Hash()
+
+	remoteTs += BlockIntervalSec
+	r3 := syntheticBlock(3, remoteTipHash, remoteTs, MinDifficulty*3)
+	if err := remote.AddBlock(r3); err != nil {
+		t.Fatalf("failed to add remote block 3: %v", err)
+	}
+
+	d := &Daemon{
+		chain:   local,
+		mempool: NewMempool(DefaultMempoolConfig(), local.IsKeyImageSpent),
+	}
+	if err := d.mempool.AddTransaction(trackedTx, trackedTx.Serialize()); err != nil {
+		t.Fatalf("failed to seed mempool: %v", err)
+	}
+
+	// Height 2 fork block is accepted off-main-chain; tx should remain in mempool.
+	r2Data, err := json.Marshal(r2)
+	if err != nil {
+		t.Fatalf("failed to marshal r2: %v", err)
+	}
+	if err := d.processBlockData(r2Data); err != nil {
+		t.Fatalf("process r2 failed: %v", err)
+	}
+	if !d.mempool.HasTransaction(trackedID) {
+		t.Fatalf("tracked tx removed before reorg connected its block")
+	}
+
+	// Height 3 makes remote fork heavier, connecting both r2 and r3 to main chain.
+	r3Data, err := json.Marshal(r3)
+	if err != nil {
+		t.Fatalf("failed to marshal r3: %v", err)
+	}
+	if err := d.processBlockData(r3Data); err != nil {
+		t.Fatalf("process r3 failed: %v", err)
+	}
+
+	if d.mempool.HasTransaction(trackedID) {
+		t.Fatalf("tracked tx should be removed after reorg connects its containing block")
+	}
+}
+
+func TestProcessBlockData_ReorgRequeuesTxsFromDisconnectedBlocks(t *testing.T) {
+	baseDir := t.TempDir()
+	local := mustNewChain(t, filepath.Join(baseDir, "local"))
+	remote := mustNewChain(t, filepath.Join(baseDir, "remote"))
+
+	genesis, err := GetGenesisBlock()
+	if err != nil {
+		t.Fatalf("failed to create genesis: %v", err)
+	}
+	if err := local.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add local genesis: %v", err)
+	}
+	if err := remote.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add remote genesis: %v", err)
+	}
+
+	commonTs := genesis.Header.Timestamp + BlockIntervalSec
+	common1 := syntheticBlock(1, genesis.Hash(), commonTs, MinDifficulty)
+	if err := local.AddBlock(cloneBlock(common1)); err != nil {
+		t.Fatalf("failed to add local shared block: %v", err)
+	}
+	if err := remote.AddBlock(cloneBlock(common1)); err != nil {
+		t.Fatalf("failed to add remote shared block: %v", err)
+	}
+
+	requeuedTx := &Transaction{
+		Version: 1,
+		Inputs: []TxInput{
+			{KeyImage: [32]byte{42}},
+		},
+		Outputs: []TxOutput{{}},
+		Fee:     10_000,
+	}
+	requeuedID, err := requeuedTx.TxID()
+	if err != nil {
+		t.Fatalf("failed to compute tx id: %v", err)
+	}
+	expectedPID := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+
+	// Local chain includes requeuedTx on the soon-to-be-disconnected branch.
+	localTs := commonTs + BlockIntervalSec
+	l2 := syntheticBlock(2, common1.Hash(), localTs, MinDifficulty)
+	l2.Transactions = []*Transaction{requeuedTx}
+	l2.AuxData = &BlockAuxData{
+		PaymentIDs: map[string][8]byte{
+			"0:0": expectedPID,
+		},
+	}
+	if err := local.AddBlock(l2); err != nil {
+		t.Fatalf("failed to add local block 2: %v", err)
+	}
+
+	localTs += BlockIntervalSec
+	l3 := syntheticBlock(3, l2.Hash(), localTs, MinDifficulty)
+	if err := local.AddBlock(l3); err != nil {
+		t.Fatalf("failed to add local block 3: %v", err)
+	}
+
+	// Remote fork only becomes heavier at height 3 (not yet at height 2).
+	remoteTs := commonTs + BlockIntervalSec
+	r2 := syntheticBlock(2, common1.Hash(), remoteTs, MinDifficulty*2)
+	if err := remote.AddBlock(r2); err != nil {
+		t.Fatalf("failed to add remote block 2: %v", err)
+	}
+
+	remoteTs += BlockIntervalSec
+	r3 := syntheticBlock(3, r2.Hash(), remoteTs, MinDifficulty*2)
+	if err := remote.AddBlock(r3); err != nil {
+		t.Fatalf("failed to add remote block 3: %v", err)
+	}
+
+	d := &Daemon{
+		chain:   local,
+		mempool: NewMempool(DefaultMempoolConfig(), local.IsKeyImageSpent),
+	}
+
+	// Accept fork block at height 2 off-main-chain; no reorg yet.
+	r2Data, err := json.Marshal(r2)
+	if err != nil {
+		t.Fatalf("failed to marshal r2: %v", err)
+	}
+	if err := d.processBlockData(r2Data); err != nil {
+		t.Fatalf("process r2 failed: %v", err)
+	}
+	if d.mempool.HasTransaction(requeuedID) {
+		t.Fatalf("tx should not be requeued before reorg")
+	}
+
+	// Height 3 triggers reorg; local l2/l3 disconnect and requeuedTx should return.
+	r3Data, err := json.Marshal(r3)
+	if err != nil {
+		t.Fatalf("failed to marshal r3: %v", err)
+	}
+	if err := d.processBlockData(r3Data); err != nil {
+		t.Fatalf("process r3 failed: %v", err)
+	}
+	if !d.mempool.HasTransaction(requeuedID) {
+		t.Fatalf("tx from disconnected block should be requeued in mempool after reorg")
+	}
+
+	_, aux, found := d.mempool.GetTransactionWithAux(requeuedID)
+	if !found {
+		t.Fatalf("requeued tx not found in mempool")
+	}
+	if aux == nil {
+		t.Fatalf("requeued tx aux data should be preserved")
+	}
+	gotPID, ok := aux.PaymentIDs[0]
+	if !ok {
+		t.Fatalf("missing output 0 payment ID in requeued tx aux")
+	}
+	if gotPID != expectedPID {
+		t.Fatalf("unexpected requeued tx payment ID: got=%x want=%x", gotPID, expectedPID)
+	}
+
+	serializedWithAux := d.mempool.GetAllTransactionDataWithAux()
+	if len(serializedWithAux) != 1 {
+		t.Fatalf("expected exactly one mempool tx, got %d", len(serializedWithAux))
+	}
+	raw, parsedAux := DecodeTxWithAux(serializedWithAux[0])
+	if parsedAux == nil {
+		t.Fatalf("serialized requeued tx missing aux trailer")
+	}
+	parsedPID, ok := parsedAux.PaymentIDs[0]
+	if !ok || parsedPID != expectedPID {
+		t.Fatalf("serialized requeued tx missing expected payment ID")
+	}
+	if !bytes.Equal(raw, requeuedTx.Serialize()) {
+		t.Fatalf("serialized requeued tx payload mismatch")
+	}
+}

--- a/mempool_reorg_test.go
+++ b/mempool_reorg_test.go
@@ -1,0 +1,107 @@
+package main
+
+import "testing"
+
+func testReorgTx(keyImageByte byte, fee uint64) *Transaction {
+	return &Transaction{
+		Version: 1,
+		Inputs: []TxInput{
+			{KeyImage: [32]byte{keyImageByte}},
+		},
+		Outputs: []TxOutput{{}},
+		Fee:     fee,
+	}
+}
+
+func TestOnBlockDisconnected_RequeuedTxMaintainsHeapInvariants(t *testing.T) {
+	m := NewMempool(DefaultMempoolConfig(), func([32]byte) bool { return false })
+
+	baseTx := &Transaction{
+		Version: 1,
+		Outputs: []TxOutput{{}},
+		Fee:     5_000,
+	}
+	baseData := baseTx.Serialize()
+	if err := m.AddTransaction(baseTx, baseData); err != nil {
+		t.Fatalf("failed to seed mempool: %v", err)
+	}
+	baseID, err := baseTx.TxID()
+	if err != nil {
+		t.Fatalf("failed to compute base tx id: %v", err)
+	}
+
+	reorgTx := testReorgTx(9, 8_000)
+	reorgID, err := reorgTx.TxID()
+	if err != nil {
+		t.Fatalf("failed to compute reorg tx id: %v", err)
+	}
+
+	m.OnBlockDisconnected(&Block{
+		Transactions: []*Transaction{reorgTx},
+	}, map[[32]byte][]byte{
+		reorgID: reorgTx.Serialize(),
+	})
+
+	if !m.HasTransaction(reorgID) {
+		t.Fatalf("requeued tx missing from mempool")
+	}
+	if len(m.priorityQueue) != 2 {
+		t.Fatalf("priority queue size mismatch after requeue: got=%d want=2", len(m.priorityQueue))
+	}
+
+	requeuedEntry := m.txByID[reorgID]
+	if requeuedEntry == nil {
+		t.Fatalf("missing mempool entry for requeued tx")
+	}
+	if requeuedEntry.index < 0 || requeuedEntry.index >= len(m.priorityQueue) {
+		t.Fatalf("requeued entry index out of bounds: %d", requeuedEntry.index)
+	}
+	if m.priorityQueue[requeuedEntry.index] != requeuedEntry {
+		t.Fatalf("priority queue index does not reference requeued entry")
+	}
+
+	m.RemoveTransaction(reorgID)
+
+	if !m.HasTransaction(baseID) {
+		t.Fatalf("removing requeued tx should not remove existing tx")
+	}
+	if len(m.priorityQueue) != 1 {
+		t.Fatalf("priority queue size mismatch after removal: got=%d want=1", len(m.priorityQueue))
+	}
+	if m.priorityQueue[0] == nil || m.priorityQueue[0].TxID != baseID {
+		t.Fatalf("unexpected tx remained in priority queue after removal")
+	}
+}
+
+func TestOnBlockDisconnected_DuplicateTxDoesNotCorruptBookkeeping(t *testing.T) {
+	m := NewMempool(DefaultMempoolConfig(), func([32]byte) bool { return false })
+
+	reorgTx := testReorgTx(7, 10_000)
+	reorgID, err := reorgTx.TxID()
+	if err != nil {
+		t.Fatalf("failed to compute reorg tx id: %v", err)
+	}
+
+	block := &Block{Transactions: []*Transaction{reorgTx}}
+	txDataMap := map[[32]byte][]byte{reorgID: reorgTx.Serialize()}
+
+	m.OnBlockDisconnected(block, txDataMap)
+
+	initialTotalSize := m.totalSize
+	initialQueueLen := len(m.priorityQueue)
+	if initialQueueLen != 1 {
+		t.Fatalf("expected one queued entry after first requeue, got %d", initialQueueLen)
+	}
+
+	m.OnBlockDisconnected(block, txDataMap)
+
+	if m.totalSize != initialTotalSize {
+		t.Fatalf("duplicate requeue changed totalSize: got=%d want=%d", m.totalSize, initialTotalSize)
+	}
+	if len(m.txByID) != 1 {
+		t.Fatalf("duplicate requeue changed tx count: got=%d want=1", len(m.txByID))
+	}
+	if len(m.priorityQueue) != initialQueueLen {
+		t.Fatalf("duplicate requeue changed priority queue size: got=%d want=%d", len(m.priorityQueue), initialQueueLen)
+	}
+}

--- a/p2p/sync_recovery_test.go
+++ b/p2p/sync_recovery_test.go
@@ -1,0 +1,397 @@
+package p2p
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+var errTestOrphan = errors.New("orphan block")
+var errTestInvalid = errors.New("invalid block body")
+
+type testBlock struct {
+	Header struct {
+		Height   uint64   `json:"Height"`
+		PrevHash [32]byte `json:"PrevHash"`
+	} `json:"header"`
+}
+
+func makeTestBlock(height uint64, prev [32]byte) ([]byte, [32]byte, error) {
+	var block testBlock
+	block.Header.Height = height
+	block.Header.PrevHash = prev
+
+	data, err := json.Marshal(block)
+	if err != nil {
+		return nil, [32]byte{}, err
+	}
+	return data, sha256.Sum256(data), nil
+}
+
+func testGetBlockMeta(data []byte) (uint64, [32]byte, error) {
+	var block testBlock
+	if err := json.Unmarshal(data, &block); err != nil {
+		return 0, [32]byte{}, err
+	}
+	return block.Header.Height, block.Header.PrevHash, nil
+}
+
+func testGetBlockHash(data []byte) ([32]byte, error) {
+	return sha256.Sum256(data), nil
+}
+
+func TestProcessBlockWithRecovery_ResolvesMissingParentChain(t *testing.T) {
+	genesisData, genesisHash, err := makeTestBlock(0, [32]byte{})
+	if err != nil {
+		t.Fatalf("genesis encode failed: %v", err)
+	}
+	_ = genesisData
+
+	// Local chain: genesis + local1.
+	local1Data, local1Hash, err := makeTestBlock(1, genesisHash)
+	if err != nil {
+		t.Fatalf("local1 encode failed: %v", err)
+	}
+	_ = local1Data
+	_ = local1Hash
+
+	// Remote fork chain: genesis + r1 + r2 + r3.
+	r1Data, r1Hash, err := makeTestBlock(1, genesisHash)
+	if err != nil {
+		t.Fatalf("r1 encode failed: %v", err)
+	}
+	r2Data, r2Hash, err := makeTestBlock(2, r1Hash)
+	if err != nil {
+		t.Fatalf("r2 encode failed: %v", err)
+	}
+	r3Data, r3Hash, err := makeTestBlock(3, r2Hash)
+	if err != nil {
+		t.Fatalf("r3 encode failed: %v", err)
+	}
+
+	known := map[[32]byte]struct{}{
+		genesisHash: {},
+		local1Hash:  {},
+	}
+
+	remoteBlocks := map[[32]byte][]byte{
+		r1Hash: r1Data,
+		r2Hash: r2Data,
+		r3Hash: r3Data,
+	}
+
+	processBlock := func(data []byte) error {
+		height, prevHash, err := testGetBlockMeta(data)
+		if err != nil {
+			return err
+		}
+		hash := sha256.Sum256(data)
+		if _, exists := known[hash]; exists {
+			return nil // duplicate
+		}
+		if height > 0 {
+			if _, hasParent := known[prevHash]; !hasParent {
+				return errTestOrphan
+			}
+		}
+		known[hash] = struct{}{}
+		return nil
+	}
+
+	fetchByHash := func(_ context.Context, _ peer.ID, hashes [][32]byte) ([][]byte, error) {
+		if len(hashes) == 0 {
+			return nil, nil
+		}
+		if data, ok := remoteBlocks[hashes[0]]; ok {
+			return [][]byte{data}, nil
+		}
+		return nil, nil
+	}
+
+	sm := NewSyncManager(nil, SyncConfig{
+		ProcessBlock:      processBlock,
+		IsOrphanError:     func(err error) bool { return errors.Is(err, errTestOrphan) },
+		GetBlockMeta:      testGetBlockMeta,
+		GetBlockHash:      testGetBlockHash,
+		FetchBlocksByHash: fetchByHash,
+	})
+
+	peers := []PeerStatus{{Peer: peer.ID("peer-1")}}
+	if err := sm.ProcessBlockWithRecovery(r3Data, peers); err != nil {
+		t.Fatalf("recovery failed: %v", err)
+	}
+
+	if _, ok := known[r1Hash]; !ok {
+		t.Fatalf("missing recovered block r1")
+	}
+	if _, ok := known[r2Hash]; !ok {
+		t.Fatalf("missing recovered block r2")
+	}
+	if _, ok := known[r3Hash]; !ok {
+		t.Fatalf("missing recovered block r3")
+	}
+}
+
+func TestProcessBlockWithRecovery_FailsWhenParentUnavailable(t *testing.T) {
+	genesisData, genesisHash, err := makeTestBlock(0, [32]byte{})
+	if err != nil {
+		t.Fatalf("genesis encode failed: %v", err)
+	}
+	_ = genesisData
+
+	// Child references unknown parent.
+	var missingParent [32]byte
+	missingParent[0] = 99
+	orphanData, _, err := makeTestBlock(2, missingParent)
+	if err != nil {
+		t.Fatalf("orphan encode failed: %v", err)
+	}
+
+	known := map[[32]byte]struct{}{
+		genesisHash: {},
+	}
+
+	processBlock := func(data []byte) error {
+		height, prevHash, err := testGetBlockMeta(data)
+		if err != nil {
+			return err
+		}
+		hash := sha256.Sum256(data)
+		if _, exists := known[hash]; exists {
+			return nil
+		}
+		if height > 0 {
+			if _, hasParent := known[prevHash]; !hasParent {
+				return errTestOrphan
+			}
+		}
+		known[hash] = struct{}{}
+		return nil
+	}
+
+	sm := NewSyncManager(nil, SyncConfig{
+		ProcessBlock:      processBlock,
+		IsOrphanError:     func(err error) bool { return errors.Is(err, errTestOrphan) },
+		GetBlockMeta:      testGetBlockMeta,
+		GetBlockHash:      testGetBlockHash,
+		FetchBlocksByHash: func(context.Context, peer.ID, [][32]byte) ([][]byte, error) { return nil, nil },
+	})
+
+	err = sm.ProcessBlockWithRecovery(orphanData, []PeerStatus{{Peer: peer.ID("peer-1")}})
+	if err == nil {
+		t.Fatalf("expected recovery failure for missing parent")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch parent") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProcessBlockWithRecovery_UsesDeadlineBoundFetchContext(t *testing.T) {
+	orphanData, _, err := makeTestBlock(2, [32]byte{1})
+	if err != nil {
+		t.Fatalf("orphan encode failed: %v", err)
+	}
+
+	deadlineSeen := make(chan bool, 1)
+
+	sm := NewSyncManager(nil, SyncConfig{
+		ProcessBlock:  func([]byte) error { return errTestOrphan },
+		IsOrphanError: func(err error) bool { return errors.Is(err, errTestOrphan) },
+		GetBlockMeta:  testGetBlockMeta,
+		GetBlockHash:  testGetBlockHash,
+		FetchBlocksByHash: func(ctx context.Context, _ peer.ID, _ [][32]byte) ([][]byte, error) {
+			_, ok := ctx.Deadline()
+			deadlineSeen <- ok
+			return nil, nil
+		},
+	})
+
+	err = sm.ProcessBlockWithRecovery(orphanData, []PeerStatus{{Peer: peer.ID("peer-1")}})
+	if err == nil {
+		t.Fatalf("expected recovery to fail when parent cannot be fetched")
+	}
+
+	select {
+	case ok := <-deadlineSeen:
+		if !ok {
+			t.Fatalf("expected fetch callback context to have a deadline")
+		}
+	default:
+		t.Fatalf("fetch callback was not invoked")
+	}
+}
+
+func TestProcessBlockWithRecoveryCtx_UsesCallerCancellation(t *testing.T) {
+	orphanData, _, err := makeTestBlock(2, [32]byte{9})
+	if err != nil {
+		t.Fatalf("orphan encode failed: %v", err)
+	}
+
+	sm := NewSyncManager(nil, SyncConfig{
+		ProcessBlock:  func([]byte) error { return errTestOrphan },
+		IsOrphanError: func(err error) bool { return errors.Is(err, errTestOrphan) },
+		GetBlockMeta:  testGetBlockMeta,
+		GetBlockHash:  testGetBlockHash,
+		FetchBlocksByHash: func(ctx context.Context, _ peer.ID, _ [][32]byte) ([][]byte, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = sm.ProcessBlockWithRecoveryCtx(ctx, orphanData, []PeerStatus{{Peer: peer.ID("peer-1")}})
+	if err == nil {
+		t.Fatalf("expected cancellation error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected caller context cancellation, got: %v", err)
+	}
+	if time.Since(start) > 500*time.Millisecond {
+		t.Fatalf("recovery did not stop promptly on caller cancellation")
+	}
+}
+
+func TestProcessBlockWithRecovery_RetriesOtherPeersOnInvalidParentData(t *testing.T) {
+	type wireBlock struct {
+		Header struct {
+			Height   uint64   `json:"Height"`
+			PrevHash [32]byte `json:"PrevHash"`
+		} `json:"header"`
+		Hash  [32]byte `json:"hash"`
+		Valid bool     `json:"valid"`
+	}
+
+	encode := func(height uint64, prev, hash [32]byte, valid bool) []byte {
+		var b wireBlock
+		b.Header.Height = height
+		b.Header.PrevHash = prev
+		b.Hash = hash
+		b.Valid = valid
+		data, err := json.Marshal(b)
+		if err != nil {
+			t.Fatalf("encode failed: %v", err)
+		}
+		return data
+	}
+	getMeta := func(data []byte) (uint64, [32]byte, error) {
+		var b wireBlock
+		if err := json.Unmarshal(data, &b); err != nil {
+			return 0, [32]byte{}, err
+		}
+		return b.Header.Height, b.Header.PrevHash, nil
+	}
+	getHash := func(data []byte) ([32]byte, error) {
+		var b wireBlock
+		if err := json.Unmarshal(data, &b); err != nil {
+			return [32]byte{}, err
+		}
+		return b.Hash, nil
+	}
+
+	var genesisHash [32]byte
+	genesisHash[0] = 1
+	var parentHash [32]byte
+	parentHash[0] = 2
+	var childHash [32]byte
+	childHash[0] = 3
+
+	parentBad := encode(1, genesisHash, parentHash, false)
+	parentGood := encode(1, genesisHash, parentHash, true)
+	child := encode(2, parentHash, childHash, true)
+
+	known := map[[32]byte]struct{}{
+		genesisHash: {},
+	}
+
+	processBlock := func(data []byte) error {
+		var b wireBlock
+		if err := json.Unmarshal(data, &b); err != nil {
+			return err
+		}
+		if _, exists := known[b.Hash]; exists {
+			return nil
+		}
+		if !b.Valid {
+			return errTestInvalid
+		}
+		if b.Header.Height > 0 {
+			if _, hasParent := known[b.Header.PrevHash]; !hasParent {
+				return errTestOrphan
+			}
+		}
+		known[b.Hash] = struct{}{}
+		return nil
+	}
+
+	sm := NewSyncManager(nil, SyncConfig{
+		ProcessBlock:  processBlock,
+		IsOrphanError: func(err error) bool { return errors.Is(err, errTestOrphan) },
+		GetBlockMeta:  getMeta,
+		GetBlockHash:  getHash,
+		FetchBlocksByHash: func(_ context.Context, p peer.ID, _ [][32]byte) ([][]byte, error) {
+			if p == peer.ID("bad-peer") {
+				return [][]byte{parentBad}, nil
+			}
+			time.Sleep(25 * time.Millisecond)
+			return [][]byte{parentGood}, nil
+		},
+	})
+
+	err := sm.ProcessBlockWithRecovery(child, []PeerStatus{
+		{Peer: peer.ID("bad-peer")},
+		{Peer: peer.ID("good-peer")},
+	})
+	if err != nil {
+		t.Fatalf("expected recovery to retry another peer after invalid parent, got: %v", err)
+	}
+
+	if _, ok := known[parentHash]; !ok {
+		t.Fatalf("missing recovered parent block")
+	}
+	if _, ok := known[childHash]; !ok {
+		t.Fatalf("missing recovered child block")
+	}
+}
+
+func TestFetchBlockByHashFromAnyPeer_VerifiesReturnedHash(t *testing.T) {
+	correctData, correctHash, err := makeTestBlock(7, [32]byte{3})
+	if err != nil {
+		t.Fatalf("correct block encode failed: %v", err)
+	}
+	wrongData, _, err := makeTestBlock(7, [32]byte{4})
+	if err != nil {
+		t.Fatalf("wrong block encode failed: %v", err)
+	}
+
+	sm := NewSyncManager(nil, SyncConfig{
+		GetBlockHash: testGetBlockHash,
+		FetchBlocksByHash: func(_ context.Context, p peer.ID, _ [][32]byte) ([][]byte, error) {
+			if p == peer.ID("bad-peer") {
+				return [][]byte{wrongData}, nil
+			}
+			time.Sleep(25 * time.Millisecond)
+			return [][]byte{correctData}, nil
+		},
+	})
+
+	block, _, err := sm.fetchBlockByHashFromAnyPeer(context.Background(), []PeerStatus{
+		{Peer: peer.ID("bad-peer")},
+		{Peer: peer.ID("good-peer")},
+	}, correctHash, nil)
+	if err != nil {
+		t.Fatalf("expected successful fetch from good peer after rejecting bad peer data: %v", err)
+	}
+	if !bytes.Equal(block, correctData) {
+		t.Fatalf("returned block did not match expected block")
+	}
+}

--- a/sync_reorg_test.go
+++ b/sync_reorg_test.go
@@ -1,0 +1,461 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"blocknet/p2p"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func TestReproSync_NearTipOverlap_DeepReorgStalls(t *testing.T) {
+	baseDir := t.TempDir()
+	local := mustNewChain(t, filepath.Join(baseDir, "local"))
+	remote := mustNewChain(t, filepath.Join(baseDir, "remote"))
+
+	genesis, err := GetGenesisBlock()
+	if err != nil {
+		t.Fatalf("failed to create genesis: %v", err)
+	}
+	if err := local.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add local genesis: %v", err)
+	}
+	if err := remote.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add remote genesis: %v", err)
+	}
+
+	// Build a common prefix, then diverge deeper than the 10-block near-tip overlap.
+	const sharedDepth uint64 = 5
+	const targetHeight uint64 = 25
+	const localDiff = MinDifficulty
+	const remoteDiff = MinDifficulty * 3
+
+	commonTipHash := genesis.Hash()
+	commonTs := genesis.Header.Timestamp
+
+	for h := uint64(1); h <= sharedDepth; h++ {
+		commonTs += BlockIntervalSec
+		block := syntheticBlock(h, commonTipHash, commonTs, MinDifficulty)
+		if err := local.AddBlock(cloneBlock(block)); err != nil {
+			t.Fatalf("failed to add local shared block %d: %v", h, err)
+		}
+		if err := remote.AddBlock(cloneBlock(block)); err != nil {
+			t.Fatalf("failed to add remote shared block %d: %v", h, err)
+		}
+		commonTipHash = block.Hash()
+	}
+
+	localTipHash := commonTipHash
+	remoteTipHash := commonTipHash
+	localTs := commonTs
+	remoteTs := commonTs
+
+	for h := sharedDepth + 1; h <= targetHeight; h++ {
+		localTs += BlockIntervalSec
+		localBlock := syntheticBlock(h, localTipHash, localTs, localDiff)
+		if err := local.AddBlock(localBlock); err != nil {
+			t.Fatalf("failed to add local fork block %d: %v", h, err)
+		}
+		localTipHash = localBlock.Hash()
+
+		remoteTs += BlockIntervalSec
+		remoteBlock := syntheticBlock(h, remoteTipHash, remoteTs, remoteDiff)
+		if err := remote.AddBlock(remoteBlock); err != nil {
+			t.Fatalf("failed to add remote fork block %d: %v", h, err)
+		}
+		remoteTipHash = remoteBlock.Hash()
+	}
+
+	if local.Height() != remote.Height() {
+		t.Fatalf("expected equal heights for reorg sync case: local=%d remote=%d", local.Height(), remote.Height())
+	}
+	if remote.TotalWork() <= local.TotalWork() {
+		t.Fatalf("test setup invalid: remote work must exceed local work")
+	}
+
+	// Simulate legacy sync attempts using the near-tip window logic, without
+	// orphan backfill recovery.
+	for attempt := 1; attempt <= 2; attempt++ {
+		err := syncAttemptLikeNearTip(local, remote)
+		if err == nil {
+			t.Fatalf("expected legacy sync attempt %d to fail with orphan", attempt)
+		}
+		if err.Error() != "process block 15: orphan block" {
+			t.Fatalf("unexpected legacy sync error (attempt %d): %v", attempt, err)
+		}
+	}
+}
+
+func TestReproSync_BehindByMoreThanOverlap_OneBlockTipForkStalls(t *testing.T) {
+	baseDir := t.TempDir()
+	local := mustNewChain(t, filepath.Join(baseDir, "local"))
+	remote := mustNewChain(t, filepath.Join(baseDir, "remote"))
+
+	genesis, err := GetGenesisBlock()
+	if err != nil {
+		t.Fatalf("failed to create genesis: %v", err)
+	}
+	if err := local.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add local genesis: %v", err)
+	}
+	if err := remote.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add remote genesis: %v", err)
+	}
+
+	// Build common chain to 59, then fork at height 60.
+	// Local stays on stale tip 60; remote extends far ahead (>50 block gap).
+	const commonTip uint64 = 59
+	const localTip uint64 = 60
+	const remoteTip uint64 = 120
+
+	commonTipHash := genesis.Hash()
+	ts := genesis.Header.Timestamp
+
+	for h := uint64(1); h <= commonTip; h++ {
+		ts += BlockIntervalSec
+		block := syntheticBlock(h, commonTipHash, ts, MinDifficulty)
+		if err := local.AddBlock(cloneBlock(block)); err != nil {
+			t.Fatalf("failed to add local shared block %d: %v", h, err)
+		}
+		if err := remote.AddBlock(cloneBlock(block)); err != nil {
+			t.Fatalf("failed to add remote shared block %d: %v", h, err)
+		}
+		commonTipHash = block.Hash()
+	}
+
+	ts += BlockIntervalSec
+	local60 := syntheticBlock(localTip, commonTipHash, ts, MinDifficulty)
+	if err := local.AddBlock(local60); err != nil {
+		t.Fatalf("failed to add local tip block: %v", err)
+	}
+
+	remoteTs := ts
+	remote60 := syntheticBlock(localTip, commonTipHash, remoteTs, MinDifficulty*2)
+	if err := remote.AddBlock(remote60); err != nil {
+		t.Fatalf("failed to add remote fork block 60: %v", err)
+	}
+	remoteTipHash := remote60.Hash()
+
+	for h := localTip + 1; h <= remoteTip; h++ {
+		remoteTs += BlockIntervalSec
+		b := syntheticBlock(h, remoteTipHash, remoteTs, MinDifficulty*2)
+		if err := remote.AddBlock(b); err != nil {
+			t.Fatalf("failed to add remote fork block %d: %v", h, err)
+		}
+		remoteTipHash = b.Hash()
+	}
+
+	if local.Height() != localTip {
+		t.Fatalf("unexpected local height: got=%d want=%d", local.Height(), localTip)
+	}
+	if remote.Height() != remoteTip {
+		t.Fatalf("unexpected remote height: got=%d want=%d", remote.Height(), remoteTip)
+	}
+	if remote.TotalWork() <= local.TotalWork() {
+		t.Fatalf("test setup invalid: remote work must exceed local work")
+	}
+
+	err = syncAttemptLikeNearTip(local, remote)
+	if err == nil {
+		t.Fatalf("expected legacy sync to fail with orphan")
+	}
+	if err.Error() != "process block 61: orphan block" {
+		t.Fatalf("unexpected legacy sync error: %v", err)
+	}
+}
+
+func mustNewChain(t *testing.T, dataDir string) *Chain {
+	t.Helper()
+
+	chain, err := NewChain(dataDir)
+	if err != nil {
+		t.Fatalf("failed to create chain at %s: %v", dataDir, err)
+	}
+	t.Cleanup(func() {
+		if err := chain.Close(); err != nil {
+			t.Errorf("failed to close chain at %s: %v", dataDir, err)
+		}
+	})
+	return chain
+}
+
+func syntheticBlock(height uint64, prevHash [32]byte, timestamp int64, difficulty uint64) *Block {
+	return &Block{
+		Header: BlockHeader{
+			Version:    1,
+			Height:     height,
+			PrevHash:   prevHash,
+			MerkleRoot: [32]byte{},
+			Timestamp:  timestamp,
+			Difficulty: difficulty,
+			Nonce:      0,
+		},
+		Transactions: []*Transaction{},
+	}
+}
+
+func cloneBlock(b *Block) *Block {
+	copied := *b
+	copied.Transactions = append([]*Transaction(nil), b.Transactions...)
+	return &copied
+}
+
+func syncAttemptLikeNearTip(local, remote *Chain) error {
+	ourHeight := local.Height()
+	targetHeight := remote.Height()
+	if targetHeight < ourHeight {
+		return nil
+	}
+
+	startHeight := ourHeight + 1
+	if gap := targetHeight - ourHeight; gap <= 50 && ourHeight > 10 {
+		startHeight = ourHeight - 10
+	}
+
+	for h := startHeight; h <= targetHeight; h++ {
+		block := remote.GetBlockByHeight(h)
+		if block == nil {
+			return fmt.Errorf("remote missing block at height %d", h)
+		}
+
+		data, err := json.Marshal(block)
+		if err != nil {
+			return fmt.Errorf("marshal block %d: %w", h, err)
+		}
+
+		if err := processBlockDataLikeDaemon(local, data); err != nil {
+			return fmt.Errorf("process block %d: %w", h, err)
+		}
+	}
+
+	return nil
+}
+
+func processBlockDataLikeDaemon(chain *Chain, data []byte) error {
+	var block Block
+	if err := json.Unmarshal(data, &block); err != nil {
+		return err
+	}
+
+	accepted, _, err := chain.ProcessBlock(&block)
+	if err != nil {
+		return err
+	}
+	if !accepted {
+		// Duplicate block we already have.
+		return nil
+	}
+
+	return nil
+}
+
+// fetchBlockByHashFromRemote builds a FetchBlocksByHash callback that serves
+// blocks from the given remote chain, keyed by hash.
+func fetchBlockByHashFromRemote(remote *Chain) func(context.Context, peer.ID, [][32]byte) ([][]byte, error) {
+	return func(_ context.Context, _ peer.ID, hashes [][32]byte) ([][]byte, error) {
+		var out [][]byte
+		for _, h := range hashes {
+			block := remote.GetBlock(h)
+			if block == nil {
+				continue
+			}
+			data, err := json.Marshal(block)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, data)
+		}
+		return out, nil
+	}
+}
+
+func syncWithRecovery(local, remote *Chain) error {
+	ourHeight := local.Height()
+	targetHeight := remote.Height()
+	if targetHeight < ourHeight {
+		return nil
+	}
+
+	startHeight := ourHeight + 1
+	if gap := targetHeight - ourHeight; gap <= 50 && ourHeight > 10 {
+		startHeight = ourHeight - 10
+	}
+
+	sm := p2p.NewSyncManager(nil, p2p.SyncConfig{
+		ProcessBlock:  func(data []byte) error { return processBlockDataLikeDaemon(local, data) },
+		IsOrphanError: func(err error) bool { return errors.Is(err, ErrOrphanBlock) },
+		GetBlockMeta: func(data []byte) (uint64, [32]byte, error) {
+			var block Block
+			if err := json.Unmarshal(data, &block); err != nil {
+				return 0, [32]byte{}, err
+			}
+			return block.Header.Height, block.Header.PrevHash, nil
+		},
+		GetBlockHash: func(data []byte) ([32]byte, error) {
+			var block Block
+			if err := json.Unmarshal(data, &block); err != nil {
+				return [32]byte{}, err
+			}
+			return block.Hash(), nil
+		},
+		FetchBlocksByHash: fetchBlockByHashFromRemote(remote),
+	})
+
+	peers := []p2p.PeerStatus{{Peer: peer.ID("test-remote")}}
+
+	for h := startHeight; h <= targetHeight; h++ {
+		block := remote.GetBlockByHeight(h)
+		if block == nil {
+			return fmt.Errorf("remote missing block at height %d", h)
+		}
+		data, err := json.Marshal(block)
+		if err != nil {
+			return fmt.Errorf("marshal block %d: %w", h, err)
+		}
+		if err := sm.ProcessBlockWithRecovery(data, peers); err != nil {
+			return fmt.Errorf("process block %d: %w", h, err)
+		}
+	}
+	return nil
+}
+
+func TestSyncWithRecovery_DeepReorg(t *testing.T) {
+	baseDir := t.TempDir()
+	local := mustNewChain(t, filepath.Join(baseDir, "local"))
+	remote := mustNewChain(t, filepath.Join(baseDir, "remote"))
+
+	genesis, err := GetGenesisBlock()
+	if err != nil {
+		t.Fatalf("failed to create genesis: %v", err)
+	}
+	if err := local.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add local genesis: %v", err)
+	}
+	if err := remote.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("failed to add remote genesis: %v", err)
+	}
+
+	const sharedDepth uint64 = 5
+	const targetHeight uint64 = 25
+	const remoteDiff = MinDifficulty * 3
+
+	commonTipHash := genesis.Hash()
+	commonTs := genesis.Header.Timestamp
+
+	for h := uint64(1); h <= sharedDepth; h++ {
+		commonTs += BlockIntervalSec
+		block := syntheticBlock(h, commonTipHash, commonTs, MinDifficulty)
+		if err := local.AddBlock(cloneBlock(block)); err != nil {
+			t.Fatalf("shared block %d: %v", h, err)
+		}
+		if err := remote.AddBlock(cloneBlock(block)); err != nil {
+			t.Fatalf("shared block %d: %v", h, err)
+		}
+		commonTipHash = block.Hash()
+	}
+
+	localTipHash := commonTipHash
+	remoteTipHash := commonTipHash
+	localTs := commonTs
+	remoteTs := commonTs
+
+	for h := sharedDepth + 1; h <= targetHeight; h++ {
+		localTs += BlockIntervalSec
+		lb := syntheticBlock(h, localTipHash, localTs, MinDifficulty)
+		if err := local.AddBlock(lb); err != nil {
+			t.Fatalf("local fork block %d: %v", h, err)
+		}
+		localTipHash = lb.Hash()
+
+		remoteTs += BlockIntervalSec
+		rb := syntheticBlock(h, remoteTipHash, remoteTs, remoteDiff)
+		if err := remote.AddBlock(rb); err != nil {
+			t.Fatalf("remote fork block %d: %v", h, err)
+		}
+		remoteTipHash = rb.Hash()
+	}
+
+	if err := syncWithRecovery(local, remote); err != nil {
+		t.Fatalf("sync with recovery failed: %v", err)
+	}
+
+	localBest, remoteBest := local.BestHash(), remote.BestHash()
+	if localBest != remoteBest {
+		t.Fatalf("chains did not converge: local=%x remote=%x", localBest[:8], remoteBest[:8])
+	}
+}
+
+func TestSyncWithRecovery_BehindByMoreThanOverlap(t *testing.T) {
+	baseDir := t.TempDir()
+	local := mustNewChain(t, filepath.Join(baseDir, "local"))
+	remote := mustNewChain(t, filepath.Join(baseDir, "remote"))
+
+	genesis, err := GetGenesisBlock()
+	if err != nil {
+		t.Fatalf("failed to create genesis: %v", err)
+	}
+	if err := local.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("local genesis: %v", err)
+	}
+	if err := remote.AddBlock(cloneBlock(genesis)); err != nil {
+		t.Fatalf("remote genesis: %v", err)
+	}
+
+	const commonTip uint64 = 59
+	const localTip uint64 = 60
+	const remoteTip uint64 = 120
+
+	commonTipHash := genesis.Hash()
+	ts := genesis.Header.Timestamp
+
+	for h := uint64(1); h <= commonTip; h++ {
+		ts += BlockIntervalSec
+		block := syntheticBlock(h, commonTipHash, ts, MinDifficulty)
+		if err := local.AddBlock(cloneBlock(block)); err != nil {
+			t.Fatalf("shared block %d: %v", h, err)
+		}
+		if err := remote.AddBlock(cloneBlock(block)); err != nil {
+			t.Fatalf("shared block %d: %v", h, err)
+		}
+		commonTipHash = block.Hash()
+	}
+
+	ts += BlockIntervalSec
+	local60 := syntheticBlock(localTip, commonTipHash, ts, MinDifficulty)
+	if err := local.AddBlock(local60); err != nil {
+		t.Fatalf("local tip: %v", err)
+	}
+
+	remoteTs := ts
+	remote60 := syntheticBlock(localTip, commonTipHash, remoteTs, MinDifficulty*2)
+	if err := remote.AddBlock(remote60); err != nil {
+		t.Fatalf("remote fork 60: %v", err)
+	}
+	remoteTipHash := remote60.Hash()
+
+	for h := localTip + 1; h <= remoteTip; h++ {
+		remoteTs += BlockIntervalSec
+		b := syntheticBlock(h, remoteTipHash, remoteTs, MinDifficulty*2)
+		if err := remote.AddBlock(b); err != nil {
+			t.Fatalf("remote fork block %d: %v", h, err)
+		}
+		remoteTipHash = b.Hash()
+	}
+
+	if err := syncWithRecovery(local, remote); err != nil {
+		t.Fatalf("sync with recovery failed: %v", err)
+	}
+
+	localBest, remoteBest := local.BestHash(), remote.BestHash()
+	if localBest != remoteBest {
+		t.Fatalf("chains did not converge: local=%x remote=%x", localBest[:8], remoteBest[:8])
+	}
+	if local.Height() != remoteTip {
+		t.Fatalf("local height mismatch: got=%d want=%d", local.Height(), remoteTip)
+	}
+}


### PR DESCRIPTION
This PR hardens reorg handling across sync and mempool so nodes can recover from orphaned blocks and keep mempool state correct after fork switches.

  It introduces two major behaviors:

  1. Orphan-chain recovery during sync (p2p/sync.go:747, p2p/sync.go:767).
  2. Reorg-aware mempool updates when main chain tip changes (daemon.go:492, daemon.go:523, mempool.go:400).

  It also adds focused regression tests for both paths (sync_reorg_test.go:327, p2p/sync_recovery_test.go:50, daemon_reorg_mempool_test.go:10, mempool_reorg_test.go:16).

  What It Changes

  1. Sync manager now supports orphan recovery callbacks via SyncConfig:
     IsOrphanError, GetBlockMeta, GetBlockHash, FetchBlocksByHash (p2p/sync.go:122).
  2. Sync block processing now uses recovery-aware flow instead of raw processBlock (p2p/sync.go:635).
  3. On orphan, sync walks backward by parent hash, fetches missing ancestors from peers, validates returned hash, retries across peers on bad data, then replays queued children
     oldest-to-newest (p2p/sync.go:767, p2p/sync.go:869).
  4. FetchBlocks now takes caller context (p2p/sync.go:1001) so recovery uses timeout/cancellation-bounded fetches.
  5. Daemon wires the new sync callbacks for real block decoding/hash/orphan classification (daemon.go:167).
  6. Daemon mempool updates are now reorg-aware:
     captures previous tip, computes disconnected/connected diff, requeues txs from disconnected blocks, removes txs confirmed on newly-connected chain (daemon.go:326,
     daemon.go:367, daemon.go:472, daemon.go:492).
  7. Requeue path now reconstructs tx aux/payment IDs from block aux metadata so wallet-facing metadata is preserved (daemon.go:610, daemon.go:642).
  8. OnBlockDisconnected fixes bookkeeping issues:
     prevents duplicate reinsert, enforces key-image conflict checks, preserves aux, and pushes requeued entries back into heap (mempool.go:416, mempool.go:432, mempool.go:458,
     mempool.go:465).

  What It Fixes

  1. Deep reorg sync stalls caused by near-tip overlap logic when ancestor is outside overlap window.
  2. “Behind by > overlap + forked tip” sync stalls (orphan on forward-only replay).
  3. Mempool inconsistency after reorg where txs from disconnected blocks were not restored correctly.
  4. Mempool inconsistency where txs in earlier newly-connected fork blocks could remain unremoved.
  5. Reorg requeue heap/index corruption risk (entry existed in map but not heap).
  6. Loss of tx aux/payment ID metadata when requeueing txs from disconnected blocks.

  Behavioral Outcome
  Nodes now converge on heavier forks without getting stuck on orphan errors, and mempool reflects the final post-reorg chain state (including aux metadata preservation).
