### PR TITLE
Add compact mining template submit path and reduce submit lock scope

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -1142,12 +1142,14 @@ func (s *APIServer) handleBlockTemplate(w http.ResponseWriter, r *http.Request) 
 
 	// Compute target for PoW validation
 	target := DifficultyToTarget(block.Header.Difficulty)
+	templateID := s.rememberMiningTemplate(block)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"block":               block,
 		"target":              fmt.Sprintf("%x", target),
 		"header_base":         fmt.Sprintf("%x", block.Header.SerializeForPoW()),
 		"reward_address_used": rewardAddrUsed,
+		"template_id":         templateID,
 	})
 }
 
@@ -1168,10 +1170,39 @@ func (s *APIServer) handleSubmitBlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var block Block
-	if err := json.NewDecoder(r.Body).Decode(&block); err != nil {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
+	}
+
+	var compact struct {
+		TemplateID string  `json:"template_id"`
+		Nonce      *uint64 `json:"nonce"`
+	}
+	if err := json.Unmarshal(body, &compact); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	var block Block
+	if strings.TrimSpace(compact.TemplateID) != "" {
+		if compact.Nonce == nil {
+			writeError(w, http.StatusBadRequest, "nonce is required with template_id")
+			return
+		}
+		tpl, ok := s.getMiningTemplate(strings.TrimSpace(compact.TemplateID))
+		if !ok {
+			writeError(w, http.StatusBadRequest, "unknown or expired template_id")
+			return
+		}
+		block = *tpl
+		block.Header.Nonce = *compact.Nonce
+	} else {
+		if err := json.Unmarshal(body, &block); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
 	}
 
 	if err := s.daemon.SubmitBlock(&block); err != nil {

--- a/api_mining_openapi_contract_test.go
+++ b/api_mining_openapi_contract_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestOpenAPIMiningCompactSubmitContract(t *testing.T) {
+	specBytes, err := os.ReadFile("api_openapi.json")
+	if err != nil {
+		t.Fatalf("failed to read api_openapi.json: %v", err)
+	}
+
+	var spec map[string]any
+	if err := json.Unmarshal(specBytes, &spec); err != nil {
+		t.Fatalf("failed to parse api_openapi.json: %v", err)
+	}
+
+	components := mustGetMapAny(t, spec, "components")
+	schemas := mustGetMapAny(t, components, "schemas")
+
+	blockTemplate := mustGetMapAny(t, schemas, "BlockTemplate")
+	blockTemplateProps := mustGetMapAny(t, blockTemplate, "properties")
+	if _, ok := blockTemplateProps["template_id"]; !ok {
+		t.Fatal("BlockTemplate schema missing template_id")
+	}
+
+	compactSubmit := mustGetMapAny(t, schemas, "CompactSubmitBlock")
+	compactProps := mustGetMapAny(t, compactSubmit, "properties")
+	if _, ok := compactProps["template_id"]; !ok {
+		t.Fatal("CompactSubmitBlock missing template_id")
+	}
+	if _, ok := compactProps["nonce"]; !ok {
+		t.Fatal("CompactSubmitBlock missing nonce")
+	}
+
+	paths := mustGetMapAny(t, spec, "paths")
+	submitPath := mustGetMapAny(t, paths, "/api/mining/submitblock")
+	submitPost := mustGetMapAny(t, submitPath, "post")
+	requestBody := mustGetMapAny(t, submitPost, "requestBody")
+	content := mustGetMapAny(t, requestBody, "content")
+	appJSON := mustGetMapAny(t, content, "application/json")
+	reqSchema := mustGetMapAny(t, appJSON, "schema")
+
+	oneOf, ok := reqSchema["oneOf"].([]any)
+	if !ok || len(oneOf) != 2 {
+		t.Fatalf("submitblock request schema must be oneOf with 2 options, got %#v", reqSchema["oneOf"])
+	}
+}
+
+func mustGetMapAny(t *testing.T, m map[string]any, key string) map[string]any {
+	t.Helper()
+	raw, ok := m[key]
+	if !ok {
+		t.Fatalf("missing key %q in OpenAPI object", key)
+	}
+	out, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("key %q is not an object in OpenAPI", key)
+	}
+	return out
+}

--- a/api_openapi.json
+++ b/api_openapi.json
@@ -1417,7 +1417,7 @@
         "operationId": "getBlockTemplate",
         "tags": ["Mining"],
         "summary": "Get block template for pool mining",
-        "description": "Returns a complete block template ready for proof-of-work solving. Includes a pre-built coinbase transaction (paying to the loaded wallet by default, or to the optional `address` override), selected mempool transactions, and the computed merkle root. The `target` field (hex) is the PoW target that the Argon2id hash must be less than. The `header_base` field (hex) is the 92-byte serialized header without the nonce, used as input to the PoW hash function. Pool software should call this to get fresh work, distribute to miners, and submit solved blocks via `POST /api/mining/submitblock`. Requires a loaded wallet (for coinbase keys) but does not require it to be unlocked.",
+        "description": "Returns a complete block template ready for proof-of-work solving. Includes a pre-built coinbase transaction (paying to the loaded wallet by default, or to the optional `address` override), selected mempool transactions, and the computed merkle root. The `target` field (hex) is the PoW target that the Argon2id hash must be less than. The `header_base` field (hex) is the 92-byte serialized header without the nonce, used as input to the PoW hash function. The `template_id` field identifies this template and can be used with compact submit payloads (`template_id` + `nonce`) via `POST /api/mining/submitblock`. Requires a loaded wallet (for coinbase keys) but does not require it to be unlocked.",
         "parameters": [
           {
             "name": "address",
@@ -1451,7 +1451,8 @@
                   },
                   "target": "000000000000f4240000000000000000000000000000000000000000000000000",
                   "header_base": "0100000080370000...",
-                  "reward_address_used": "3wZc3y1Qw4eYpZtGJxkqkV6xG9c2oXHqfJjQ6b3sR5hYhJ8tZz1qvJ1mY1a9o7hV4pYwqH7xG5d5d8cJ8p4"
+                  "reward_address_used": "3wZc3y1Qw4eYpZtGJxkqkV6xG9c2oXHqfJjQ6b3sR5hYhJ8tZz1qvJ1mY1a9o7hV4pYwqH7xG5d5d8cJ8p4",
+                  "template_id": "7b3d2f4a9d11c8ef"
                 }
               }
             }
@@ -1473,9 +1474,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Block"
+                "oneOf": [
+                  { "$ref": "#/components/schemas/Block" },
+                  { "$ref": "#/components/schemas/CompactSubmitBlock" }
+                ]
               },
-              "description": "A complete block object with a valid nonce. Typically obtained from `GET /api/mining/blocktemplate` with the nonce field filled in after PoW solving."
+              "description": "Either a complete block object with a valid nonce, or a compact payload containing `template_id` and `nonce`."
             }
           }
         },
@@ -2142,6 +2146,24 @@
           "reward_address_used": {
             "type": "string",
             "description": "The stealth address used for the coinbase output in this template. Mirrors the `address` query parameter if provided; otherwise it is the loaded wallet address."
+          },
+          "template_id": {
+            "type": "string",
+            "description": "Opaque template identifier used for compact submit payloads (`template_id` + `nonce`)."
+          }
+        }
+      },
+      "CompactSubmitBlock": {
+        "type": "object",
+        "required": ["template_id", "nonce"],
+        "properties": {
+          "template_id": {
+            "type": "string",
+            "description": "Template ID returned by GET /api/mining/blocktemplate."
+          },
+          "nonce": {
+            "type": "integer",
+            "description": "PoW nonce found for the referenced template."
           }
         }
       },

--- a/api_server.go
+++ b/api_server.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
@@ -56,7 +58,21 @@ type APIServer struct {
 
 	// Wallet unlock brute-force controls.
 	unlockAttempts *unlockAttemptTracker
+
+	// Template cache for compact mining submissions ({template_id, nonce}).
+	templateMu    sync.Mutex
+	templateCache map[string]cachedMiningTemplate
 }
+
+type cachedMiningTemplate struct {
+	block     Block
+	createdAt time.Time
+}
+
+const (
+	maxMiningTemplateCacheEntries = 512
+	miningTemplateCacheTTL        = 10 * time.Minute
+)
 
 type perIPLimiter struct {
 	mu      sync.Mutex
@@ -202,12 +218,76 @@ func NewAPIServer(daemon *Daemon, w *wallet.Wallet, scanner *wallet.Scanner, dat
 		sendIdem:           newIdempotencyCache(10*time.Minute, 1024),
 		verifyLimiter:      newPerIPLimiter(rate.Limit(5), 10, 10*time.Minute),
 		unlockAttempts:     newUnlockAttemptTracker(),
+		templateCache:      make(map[string]cachedMiningTemplate),
 	}
 	if len(password) > 0 {
 		s.passwordHash = passwordHash(password)
 		s.passwordHashSet = true
 	}
 	return s
+}
+
+func (s *APIServer) rememberMiningTemplate(block *Block) string {
+	if block == nil {
+		return ""
+	}
+
+	idBytes := make([]byte, 8)
+	if _, err := rand.Read(idBytes); err != nil {
+		now := time.Now().UnixNano()
+		for i := 0; i < len(idBytes); i++ {
+			idBytes[i] = byte(now >> (8 * i))
+		}
+	}
+	templateID := hex.EncodeToString(idBytes)
+
+	s.templateMu.Lock()
+	defer s.templateMu.Unlock()
+
+	s.pruneMiningTemplatesLocked(time.Now())
+	s.templateCache[templateID] = cachedMiningTemplate{
+		block:     *block,
+		createdAt: time.Now(),
+	}
+	if len(s.templateCache) > maxMiningTemplateCacheEntries {
+		var oldestID string
+		var oldestTime time.Time
+		for id, tpl := range s.templateCache {
+			if oldestID == "" || tpl.createdAt.Before(oldestTime) {
+				oldestID = id
+				oldestTime = tpl.createdAt
+			}
+		}
+		delete(s.templateCache, oldestID)
+	}
+
+	return templateID
+}
+
+func (s *APIServer) getMiningTemplate(templateID string) (*Block, bool) {
+	if templateID == "" {
+		return nil, false
+	}
+
+	now := time.Now()
+	s.templateMu.Lock()
+	defer s.templateMu.Unlock()
+
+	s.pruneMiningTemplatesLocked(now)
+	tpl, ok := s.templateCache[templateID]
+	if !ok {
+		return nil, false
+	}
+	block := tpl.block
+	return &block, true
+}
+
+func (s *APIServer) pruneMiningTemplatesLocked(now time.Time) {
+	for id, tpl := range s.templateCache {
+		if now.Sub(tpl.createdAt) > miningTemplateCacheTTL {
+			delete(s.templateCache, id)
+		}
+	}
 }
 
 // isLocked returns whether the wallet is locked.
@@ -233,7 +313,6 @@ func (s *APIServer) requireWallet(w http.ResponseWriter, _ *http.Request) bool {
 
 // Start launches the full authenticated API server.
 func (s *APIServer) Start(addr string) error {
-	
 
 	token, err := generateToken()
 	if err != nil {
@@ -267,8 +346,6 @@ func (s *APIServer) Start(addr string) error {
 		deleteCookie(s.dataDir)
 		return fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
-
-	
 
 	go func() {
 		if err := s.server.Serve(ln); err != nil && err != http.ErrServerClosed {

--- a/api_submitblock_compact_test.go
+++ b/api_submitblock_compact_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleSubmitBlock_CompactPayloadUsesTemplateCache(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	d := &Daemon{chain: chain}
+	s := NewAPIServer(d, nil, nil, t.TempDir(), nil)
+
+	var wrongPrev [32]byte
+	wrongPrev[0] = 1
+	template := &Block{
+		Header: BlockHeader{
+			Version:  1,
+			Height:   chain.Height() + 1,
+			PrevHash: wrongPrev,
+			Nonce:    0,
+		},
+	}
+	templateID := s.rememberMiningTemplate(template)
+	if templateID == "" {
+		t.Fatal("expected non-empty template id")
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"template_id": templateID,
+		"nonce":       uint64(7),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/mining/submitblock", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.handleSubmitBlock(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%q", rr.Code, rr.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := resp["error"]; got != "block rejected as stale" {
+		t.Fatalf("unexpected response error %q body=%q", got, rr.Body.String())
+	}
+}
+
+func TestHandleSubmitBlock_CompactPayloadUnknownTemplate(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	d := &Daemon{chain: chain}
+	s := NewAPIServer(d, nil, nil, t.TempDir(), nil)
+
+	body, err := json.Marshal(map[string]any{
+		"template_id": "missing-template",
+		"nonce":       uint64(7),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/mining/submitblock", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.handleSubmitBlock(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%q", rr.Code, rr.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := resp["error"]; got != "unknown or expired template_id" {
+		t.Fatalf("unexpected response error %q body=%q", got, rr.Body.String())
+	}
+}

--- a/daemon.go
+++ b/daemon.go
@@ -554,8 +554,6 @@ func (d *Daemon) Start() error {
 		}()
 	}
 
-	
-
 	return nil
 }
 
@@ -1161,18 +1159,19 @@ func (d *Daemon) MinerStats() MinerStats {
 // SubmitBlock validates a mined block, adds it to the chain, and broadcasts to peers.
 func (d *Daemon) SubmitBlock(block *Block) error {
 	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	if err := d.validateSubmitBlockStaleLocked(block); err != nil {
+		d.mu.Unlock()
 		return err
 	}
 
 	prevBest := d.chain.BestHash()
 	accepted, isMainChain, err := d.chain.ProcessBlock(block)
 	if err != nil {
+		d.mu.Unlock()
 		return fmt.Errorf("failed to process block: %w", err)
 	}
 	if !accepted {
+		d.mu.Unlock()
 		return fmt.Errorf("block not accepted (duplicate or stale)")
 	}
 
@@ -1181,6 +1180,7 @@ func (d *Daemon) SubmitBlock(block *Block) error {
 		d.maybeAppendCheckpointLocked(block)
 		d.miner.NotifyNewBlock()
 	}
+	d.mu.Unlock()
 
 	// Broadcast to peers
 	blockData, err := json.Marshal(block)


### PR DESCRIPTION
Summary
  This MR improves pool block-submission latency by adding a compact submit flow and trimming lock hold time in daemon block submission.

  What changed

  - GET /api/mining/blocktemplate now returns template_id.
  - Daemon caches recent templates (bounded + TTL).
  - POST /api/mining/submitblock now accepts either:
      - full Block payload, or
      - compact payload { "template_id": "...", "nonce": ... }.
  - Daemon.SubmitBlock now releases the daemon mutex before block broadcast/notifications (keeps critical state updates protected, but shortens lock scope).
  - OpenAPI updated to document template_id and oneOf submit schema.
  - Added tests for compact submit behavior and OpenAPI contract.

  Impact

  - Smaller payload and less JSON work for pool submissions.
  - Faster block-submit path under contention.
  - Backward-compatible with existing full-block submit clients.
