### PR TITLE
Fix recover orphan chain not using correct spent key image store 

### DIFF
--- a/block.go
+++ b/block.go
@@ -1551,12 +1551,14 @@ func (c *Chain) validateBlockForProcessLocked(block *Block) error {
 	)
 }
 
-// branchAwareSpentCheckerLocked returns a spent-check closure that includes
-// key images used on the candidate block's parent branch, even when those
-// ancestors are currently off-main-chain.
+// branchAwareSpentCheckerLocked returns a spent-check closure scoped to the
+// candidate block's parent branch. It includes key images used on off-main-chain
+// ancestors of that branch, while ignoring canonical spends that only occur
+// above the branch's fork point on the current main chain.
 func (c *Chain) branchAwareSpentCheckerLocked(parentHash [32]byte) (KeyImageChecker, error) {
 	branchSpent := make(map[[32]byte]struct{})
 	currentHash := parentHash
+	commonHeight := uint64(0)
 
 	for {
 		parent := c.getBlockByHashLocked(currentHash)
@@ -1566,6 +1568,7 @@ func (c *Chain) branchAwareSpentCheckerLocked(parentHash [32]byte) (KeyImageChec
 
 		mainHashAtHeight, onMainHeight := c.byHeight[parent.Header.Height]
 		if onMainHeight && mainHashAtHeight == currentHash {
+			commonHeight = parent.Header.Height
 			break
 		}
 
@@ -1588,7 +1591,11 @@ func (c *Chain) branchAwareSpentCheckerLocked(parentHash [32]byte) (KeyImageChec
 		if _, exists := branchSpent[keyImage]; exists {
 			return true
 		}
-		return c.isKeyImageSpentLocked(keyImage)
+		if spentHeight, exists := c.keyImages[keyImage]; exists {
+			return spentHeight <= commonHeight
+		}
+		spent, spentHeight := c.storage.IsKeyImageSpent(keyImage)
+		return spent && spentHeight <= commonHeight
 	}, nil
 }
 

--- a/block_branch_keyimage_test.go
+++ b/block_branch_keyimage_test.go
@@ -2,7 +2,7 @@ package main
 
 import "testing"
 
-func TestBranchAwareSpentCheckerIncludesSideBranchAncestry(t *testing.T) {
+func TestBranchAwareSpentCheckerScopesSpendsToCandidateBranch(t *testing.T) {
 	chain, _, cleanup := mustCreateTestChain(t)
 	defer cleanup()
 	mustAddGenesisBlock(t, chain)
@@ -13,16 +13,19 @@ func TestBranchAwareSpentCheckerIncludesSideBranchAncestry(t *testing.T) {
 	}
 	genesisHash := genesis.Hash()
 
-	var mainChainKeyImage [32]byte
-	mainChainKeyImage[0] = 0x11
+	var commonAncestorKeyImage [32]byte
+	commonAncestorKeyImage[0] = 0x11
+
+	var divergentMainChainKeyImage [32]byte
+	divergentMainChainKeyImage[0] = 0x22
 
 	var sideBranchKeyImage [32]byte
-	sideBranchKeyImage[0] = 0x22
+	sideBranchKeyImage[0] = 0x33
 
 	var unrelatedBranchKeyImage [32]byte
-	unrelatedBranchKeyImage[0] = 0x33
+	unrelatedBranchKeyImage[0] = 0x44
 
-	mainBlock := &Block{
+	commonAncestor := &Block{
 		Header: BlockHeader{
 			Version:    1,
 			Height:     1,
@@ -30,15 +33,42 @@ func TestBranchAwareSpentCheckerIncludesSideBranchAncestry(t *testing.T) {
 			Timestamp:  genesis.Header.Timestamp + 1,
 			Difficulty: MinDifficulty,
 		},
+		Transactions: []*Transaction{
+			{
+				Version: 1,
+				Inputs: []TxInput{
+					{KeyImage: commonAncestorKeyImage},
+				},
+			},
+		},
 	}
-	mainHash := mainBlock.Hash()
+	commonAncestorHash := commonAncestor.Hash()
+
+	mainTip := &Block{
+		Header: BlockHeader{
+			Version:    1,
+			Height:     2,
+			PrevHash:   commonAncestorHash,
+			Timestamp:  genesis.Header.Timestamp + 2,
+			Difficulty: MinDifficulty,
+		},
+		Transactions: []*Transaction{
+			{
+				Version: 1,
+				Inputs: []TxInput{
+					{KeyImage: divergentMainChainKeyImage},
+				},
+			},
+		},
+	}
+	mainTipHash := mainTip.Hash()
 
 	sideParent := &Block{
 		Header: BlockHeader{
 			Version:    1,
-			Height:     1,
-			PrevHash:   genesisHash,
-			Timestamp:  genesis.Header.Timestamp + 2,
+			Height:     2,
+			PrevHash:   commonAncestorHash,
+			Timestamp:  genesis.Header.Timestamp + 3,
 			Difficulty: MinDifficulty,
 		},
 		Transactions: []*Transaction{
@@ -55,9 +85,9 @@ func TestBranchAwareSpentCheckerIncludesSideBranchAncestry(t *testing.T) {
 	sideTip := &Block{
 		Header: BlockHeader{
 			Version:    1,
-			Height:     2,
+			Height:     3,
 			PrevHash:   sideParentHash,
-			Timestamp:  genesis.Header.Timestamp + 3,
+			Timestamp:  genesis.Header.Timestamp + 4,
 			Difficulty: MinDifficulty,
 		},
 	}
@@ -66,9 +96,9 @@ func TestBranchAwareSpentCheckerIncludesSideBranchAncestry(t *testing.T) {
 	unrelatedSide := &Block{
 		Header: BlockHeader{
 			Version:    1,
-			Height:     1,
-			PrevHash:   genesisHash,
-			Timestamp:  genesis.Header.Timestamp + 4,
+			Height:     2,
+			PrevHash:   commonAncestorHash,
+			Timestamp:  genesis.Header.Timestamp + 5,
 			Difficulty: MinDifficulty,
 		},
 		Transactions: []*Transaction{
@@ -85,24 +115,33 @@ func TestBranchAwareSpentCheckerIncludesSideBranchAncestry(t *testing.T) {
 	chain.mu.Lock()
 	defer chain.mu.Unlock()
 
-	chain.blocks[mainHash] = mainBlock
-	chain.byHeight[1] = mainHash
-	chain.keyImages[mainChainKeyImage] = 1
+	chain.blocks[commonAncestorHash] = commonAncestor
+	chain.byHeight[1] = commonAncestorHash
+	chain.keyImages[commonAncestorKeyImage] = 1
+
+	chain.blocks[mainTipHash] = mainTip
+	chain.byHeight[2] = mainTipHash
+	chain.keyImages[divergentMainChainKeyImage] = 2
 
 	chain.blocks[sideParentHash] = sideParent
 	chain.blocks[sideTipHash] = sideTip
 	chain.blocks[unrelatedSideHash] = unrelatedSide
+	chain.bestHash = mainTipHash
+	chain.height = 2
 
 	checker, err := chain.branchAwareSpentCheckerLocked(sideTipHash)
 	if err != nil {
 		t.Fatalf("failed to construct branch-aware spent checker: %v", err)
 	}
 
+	if !checker(commonAncestorKeyImage) {
+		t.Fatal("expected common-ancestor key image to remain spent")
+	}
+	if checker(divergentMainChainKeyImage) {
+		t.Fatal("expected divergent main-chain key image above the fork point to be ignored")
+	}
 	if !checker(sideBranchKeyImage) {
 		t.Fatal("expected side-branch ancestor key image to be treated as spent")
-	}
-	if !checker(mainChainKeyImage) {
-		t.Fatal("expected canonical main-chain key image to still be treated as spent")
 	}
 	if checker(unrelatedBranchKeyImage) {
 		t.Fatal("expected unrelated side-branch key image to not be treated as spent")

--- a/p2p/sync.go
+++ b/p2p/sync.go
@@ -115,8 +115,8 @@ type SyncManager struct {
 	syncing        bool
 	syncPeer       peer.ID
 	syncStartTime  time.Time
-	syncTarget     uint64            // Target height we're syncing to
-	syncProgress   uint64            // Current height we've processed to
+	syncTarget     uint64                     // Target height we're syncing to
+	syncProgress   uint64                     // Current height we've processed to
 	downloadBuffer map[uint64]DownloadedBlock // Buffer for out-of-order blocks
 
 	ctx    context.Context
@@ -656,7 +656,6 @@ func (sm *SyncManager) parallelSyncFrom(peers []PeerStatus, targetHeight uint64)
 	sm.syncProgress = ourStatus.Height
 	sm.mu.Unlock()
 
-
 	// Use up to 3 peers for parallel download
 	numDownloaders := min(len(peers), 3)
 
@@ -807,7 +806,6 @@ func (sm *SyncManager) parallelSyncFrom(peers []PeerStatus, targetHeight uint64)
 
 			nextHeight++
 
-			
 		}
 	}()
 
@@ -1027,9 +1025,12 @@ outer:
 					continue outer
 				}
 
-				// This peer returned hash-matching data that still fails validation.
-				// Keep trying other peers for the same parent hash before failing.
-				sm.banInvalidBlockPeer(sourcePeer, "invalid parent block data during orphan recovery")
+				// At this point the response was non-empty, decodable, and hash-matching.
+				// A processBlock failure here can still come from our local branch context
+				// (for example, a competing-fork spend that conflicts only with the
+				// current canonical branch above the fork point), so do not ban the
+				// serving peer on this path. Keep trying other peers for the same parent
+				// hash before failing the recovery attempt.
 				invalidPeers[sourcePeer] = struct{}{}
 				lastProcessErr = err
 				continue

--- a/p2p/sync_penalty_test.go
+++ b/p2p/sync_penalty_test.go
@@ -2,7 +2,9 @@ package p2p
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -37,9 +39,9 @@ func TestHandleNewBlock_DoesNotPenalizeOrphanOrDuplicate(t *testing.T) {
 		n := newPenaltyTestNode()
 		orph := errors.New("orphan")
 		sm := NewSyncManager(n, SyncConfig{
-			ProcessBlock:      func(data []byte) error { return orph },
-			IsOrphanError:     func(err error) bool { return errors.Is(err, orph) },
-			IsDuplicateError:  func(error) bool { return false },
+			ProcessBlock:     func(data []byte) error { return orph },
+			IsOrphanError:    func(err error) bool { return errors.Is(err, orph) },
+			IsDuplicateError: func(error) bool { return false },
 		})
 		sm.handleNewBlock(peer.ID("12D3KooWOrphanPeer000001"), []byte("orphan"))
 		if got := n.BannedCount(); got != 0 {
@@ -51,9 +53,9 @@ func TestHandleNewBlock_DoesNotPenalizeOrphanOrDuplicate(t *testing.T) {
 		n := newPenaltyTestNode()
 		dup := errors.New("duplicate")
 		sm := NewSyncManager(n, SyncConfig{
-			ProcessBlock:      func(data []byte) error { return dup },
-			IsOrphanError:     func(error) bool { return false },
-			IsDuplicateError:  func(err error) bool { return errors.Is(err, dup) },
+			ProcessBlock:     func(data []byte) error { return dup },
+			IsOrphanError:    func(error) bool { return false },
+			IsDuplicateError: func(err error) bool { return errors.Is(err, dup) },
 		})
 		sm.handleNewBlock(peer.ID("12D3KooWDuplicatePeer0001"), []byte("dup"))
 		if got := n.BannedCount(); got != 0 {
@@ -129,4 +131,81 @@ func TestFetchBlockByHashFromAnyPeer_PenalizesEmptyUndecodableAndMismatched(t *t
 			t.Fatalf("expected mismatched-hash response peer penalty, bannedCount=%d", got)
 		}
 	})
+}
+
+func TestProcessBlockWithRecoveryCtx_DoesNotBanPeerForHashMatchingParentValidationFailure(t *testing.T) {
+	errOrphan := errors.New("orphan")
+	errParent := errors.New("double-spend on competing fork")
+	parentHash := [32]byte{0xAA}
+	childHash := [32]byte{0xBB}
+
+	parentData := encodeRecoveryBlock(t, recoveryTestBlock{
+		Height: 10,
+		Hash:   parentHash,
+		Prev:   [32]byte{0x09},
+	})
+	childData := encodeRecoveryBlock(t, recoveryTestBlock{
+		Height: 11,
+		Hash:   childHash,
+		Prev:   parentHash,
+	})
+
+	n := newPenaltyTestNode()
+	pid := peer.ID("12D3KooWRecoveryNoBanPeer1")
+	sm := NewSyncManager(n, SyncConfig{
+		ProcessBlock: func(data []byte) error {
+			var b recoveryTestBlock
+			if err := json.Unmarshal(data, &b); err != nil {
+				return err
+			}
+			switch b.Hash {
+			case childHash:
+				return errOrphan
+			case parentHash:
+				return errParent
+			default:
+				return nil
+			}
+		},
+		IsOrphanError:    func(err error) bool { return errors.Is(err, errOrphan) },
+		IsDuplicateError: func(error) bool { return false },
+		GetBlockMeta: func(data []byte) (uint64, [32]byte, error) {
+			var b recoveryTestBlock
+			if err := json.Unmarshal(data, &b); err != nil {
+				return 0, [32]byte{}, err
+			}
+			return b.Height, b.Prev, nil
+		},
+		GetBlockHash: func(data []byte) ([32]byte, error) {
+			var b recoveryTestBlock
+			if err := json.Unmarshal(data, &b); err != nil {
+				return [32]byte{}, err
+			}
+			return b.Hash, nil
+		},
+		FetchBlocksByHash: func(ctx context.Context, p peer.ID, hashes [][32]byte) ([][]byte, error) {
+			if p != pid {
+				return nil, errors.New("unexpected peer")
+			}
+			if len(hashes) == 1 && hashes[0] == parentHash {
+				return [][]byte{parentData}, nil
+			}
+			return nil, errors.New("unexpected hash request")
+		},
+	})
+
+	peers := []PeerStatus{{Peer: pid}}
+	accepted, err := sm.ProcessBlockWithRecoveryCtx(context.Background(), childData, peers)
+	if err == nil {
+		t.Fatal("expected orphan recovery to fail on parent validation error")
+	}
+	if accepted {
+		t.Fatal("expected failed orphan recovery to not report acceptance")
+	}
+	if !strings.Contains(err.Error(), errParent.Error()) {
+		t.Fatalf("expected orphan recovery error to retain parent validation failure, got: %v", err)
+	}
+	if got := n.BannedCount(); got != 0 {
+		t.Fatalf("expected hash-matching parent validation failure to avoid peer ban, bannedCount=%d", got)
+	}
 }


### PR DESCRIPTION
This fixes a false-invalid path during orphan recovery on competing forks. The daemon’s branch-aware spent-key-image check was still consulting canonical spent state above the
  fork point, which could cause a valid parent block from an alternate branch to be rejected as a double-spend. The patch scopes that check to the candidate branch’s common ancestor
  and adds a regression test for it.

  It also makes orphan recovery more conservative about peer bans: peers are still banned for empty, undecodable, or hash-mismatched block responses, but not merely because a hash-
  matching parent block failed full local processing on this path, since that validation can still depend on local chain context. A second regression test covers that behavior.