### PR TITLE
Make fork ring-member validation branch-aware

### DIFF
--- a/block.go
+++ b/block.go
@@ -957,6 +957,7 @@ type Chain struct {
 	// Indexed canonical ring-member membership for main-chain outputs.
 	// Key format: pubkey(32) || commitment(32).
 	canonicalRingIndex      map[[64]byte]struct{}
+	canonicalRingHeights    map[[64]byte]uint64
 	canonicalRingIndexDirty bool
 	canonicalRingIndexTip   [32]byte
 	canonicalRingIndexReady bool
@@ -1101,6 +1102,7 @@ func NewChain(dataDir string) (*Chain, error) {
 		timestamps:              make([]int64, 0, LWMAWindow+1),
 		keyImages:               make(map[[32]byte]uint64),
 		canonicalRingIndex:      make(map[[64]byte]struct{}),
+		canonicalRingHeights:    make(map[[64]byte]uint64),
 		canonicalRingIndexDirty: true,
 		canonicalRingIndexReady: false,
 	}
@@ -1513,12 +1515,19 @@ func (c *Chain) ProcessBlock(block *Block) (accepted bool, isMainChain bool, err
 
 func (c *Chain) validateBlockForProcessLocked(block *Block) error {
 	isSpent := c.isKeyImageSpentLocked
+	isCanonicalRingMember := c.isCanonicalRingMemberLocked
 	if block != nil && block.Header.Height > 0 {
 		branchAwareSpent, err := c.branchAwareSpentCheckerLocked(block.Header.PrevHash)
 		if err != nil {
 			return err
 		}
 		isSpent = branchAwareSpent
+
+		branchAwareRingMembers, err := c.branchAwareRingMemberCheckerLocked(block.Header.PrevHash)
+		if err != nil {
+			return err
+		}
+		isCanonicalRingMember = branchAwareRingMembers
 	}
 
 	// If checkpoints are enabled for fast sync, enforce checkpoint pinning.
@@ -1546,7 +1555,7 @@ func (c *Chain) validateBlockForProcessLocked(block *Block) error {
 		c.height,
 		c.getBlockByHashLocked,
 		isSpent,
-		c.isCanonicalRingMemberLocked,
+		isCanonicalRingMember,
 		skipPoW,
 	)
 }
@@ -1596,6 +1605,53 @@ func (c *Chain) branchAwareSpentCheckerLocked(parentHash [32]byte) (KeyImageChec
 		}
 		spent, spentHeight := c.storage.IsKeyImageSpent(keyImage)
 		return spent && spentHeight <= commonHeight
+	}, nil
+}
+
+// branchAwareRingMemberCheckerLocked returns a ring-member checker scoped to the
+// candidate block's parent branch. It includes outputs created on off-main-chain
+// ancestors of that branch, while ignoring canonical-only outputs that appear
+// above the branch's fork point on the current main chain.
+func (c *Chain) branchAwareRingMemberCheckerLocked(parentHash [32]byte) (RingMemberChecker, error) {
+	if err := c.ensureCanonicalRingIndexLocked(); err != nil {
+		return nil, err
+	}
+
+	branchOutputs := make(map[[64]byte]struct{})
+	currentHash := parentHash
+	commonHeight := uint64(0)
+
+	for {
+		parent := c.getBlockByHashLocked(currentHash)
+		if parent == nil {
+			return nil, ErrOrphanBlock
+		}
+
+		mainHashAtHeight, onMainHeight := c.byHeight[parent.Header.Height]
+		if onMainHeight && mainHashAtHeight == currentHash {
+			commonHeight = parent.Header.Height
+			break
+		}
+
+		for _, tx := range parent.Transactions {
+			for _, out := range tx.Outputs {
+				branchOutputs[canonicalRingIndexKey(out.PublicKey, out.Commitment)] = struct{}{}
+			}
+		}
+
+		if parent.Header.Height == 0 {
+			break
+		}
+		currentHash = parent.Header.PrevHash
+	}
+
+	return func(pubKey, commitment [32]byte) bool {
+		key := canonicalRingIndexKey(pubKey, commitment)
+		if _, exists := branchOutputs[key]; exists {
+			return true
+		}
+		memberHeight, exists := c.canonicalRingHeights[key]
+		return exists && memberHeight <= commonHeight
 	}, nil
 }
 
@@ -1732,6 +1788,7 @@ func (c *Chain) ensureCanonicalRingIndexLocked() error {
 	tipHash, tipHeight, _, found := c.storage.GetTip()
 	if !found {
 		c.canonicalRingIndex = make(map[[64]byte]struct{})
+		c.canonicalRingHeights = make(map[[64]byte]uint64)
 		c.canonicalRingIndexTip = [32]byte{}
 		c.canonicalRingIndexReady = true
 		c.canonicalRingIndexDirty = false
@@ -1743,6 +1800,7 @@ func (c *Chain) ensureCanonicalRingIndexLocked() error {
 	}
 
 	index := make(map[[64]byte]struct{})
+	heights := make(map[[64]byte]uint64)
 	for h := uint64(0); h <= tipHeight; h++ {
 		hash, hasHeight := c.storage.GetBlockHashByHeight(h)
 		if !hasHeight {
@@ -1756,12 +1814,17 @@ func (c *Chain) ensureCanonicalRingIndexLocked() error {
 
 		for _, tx := range block.Transactions {
 			for _, out := range tx.Outputs {
-				index[canonicalRingIndexKey(out.PublicKey, out.Commitment)] = struct{}{}
+				key := canonicalRingIndexKey(out.PublicKey, out.Commitment)
+				index[key] = struct{}{}
+				if _, exists := heights[key]; !exists {
+					heights[key] = h
+				}
 			}
 		}
 	}
 
 	c.canonicalRingIndex = index
+	c.canonicalRingHeights = heights
 	c.canonicalRingIndexTip = tipHash
 	c.canonicalRingIndexReady = true
 	c.canonicalRingIndexDirty = false

--- a/block_branch_ringmember_test.go
+++ b/block_branch_ringmember_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func makeOutputOnlyTestBlock(height uint64, prevHash [32]byte, timestamp int64, outputs []TxOutput) *Block {
+	return &Block{
+		Header: BlockHeader{
+			Version:    1,
+			Height:     height,
+			PrevHash:   prevHash,
+			Timestamp:  timestamp,
+			Difficulty: MinDifficulty,
+		},
+		Transactions: []*Transaction{
+			{
+				Version: 1,
+				Outputs: outputs,
+			},
+		},
+	}
+}
+
+func blockOutputsForCommit(t *testing.T, block *Block) []*UTXO {
+	t.Helper()
+
+	var outputs []*UTXO
+	for _, tx := range block.Transactions {
+		txID, err := tx.TxID()
+		if err != nil {
+			t.Fatalf("failed to hash tx outputs: %v", err)
+		}
+		for idx, out := range tx.Outputs {
+			outputs = append(outputs, &UTXO{
+				TxID:        txID,
+				OutputIndex: uint32(idx),
+				Output:      out,
+				BlockHeight: block.Header.Height,
+			})
+		}
+	}
+	return outputs
+}
+
+func commitMainChainBlockForTest(t *testing.T, chain *Chain, storage *Storage, block *Block, work uint64) {
+	t.Helper()
+
+	hash := block.Hash()
+	if err := storage.CommitBlock(&BlockCommit{
+		Block:      block,
+		Height:     block.Header.Height,
+		Hash:       hash,
+		Work:       work,
+		IsMainTip:  true,
+		NewOutputs: blockOutputsForCommit(t, block),
+	}); err != nil {
+		t.Fatalf("failed to commit block at height %d: %v", block.Header.Height, err)
+	}
+
+	chain.mu.Lock()
+	defer chain.mu.Unlock()
+	chain.blocks[hash] = block
+	chain.workAt[hash] = work
+	chain.byHeight[block.Header.Height] = hash
+	chain.bestHash = hash
+	chain.height = block.Header.Height
+	chain.totalWork = work
+	chain.canonicalRingIndexDirty = true
+}
+
+func TestBranchAwareRingMemberCheckerScopesOutputsToCandidateBranch(t *testing.T) {
+	chain, storage, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	genesis := chain.GetBlockByHeight(0)
+	if genesis == nil {
+		t.Fatal("expected genesis block")
+	}
+
+	var commonPub, commonComm [32]byte
+	commonPub[0] = 0x11
+	commonComm[0] = 0x12
+
+	var mainPub, mainComm [32]byte
+	mainPub[0] = 0x21
+	mainComm[0] = 0x22
+
+	var sidePub, sideComm [32]byte
+	sidePub[0] = 0x31
+	sideComm[0] = 0x32
+
+	var unrelatedPub, unrelatedComm [32]byte
+	unrelatedPub[0] = 0x41
+	unrelatedComm[0] = 0x42
+
+	commonAncestor := makeOutputOnlyTestBlock(
+		1,
+		genesis.Hash(),
+		genesis.Header.Timestamp+BlockIntervalSec,
+		[]TxOutput{{PublicKey: commonPub, Commitment: commonComm}},
+	)
+	commitMainChainBlockForTest(t, chain, storage, commonAncestor, 2)
+
+	mainTip := makeOutputOnlyTestBlock(
+		2,
+		commonAncestor.Hash(),
+		commonAncestor.Header.Timestamp+BlockIntervalSec,
+		[]TxOutput{{PublicKey: mainPub, Commitment: mainComm}},
+	)
+	commitMainChainBlockForTest(t, chain, storage, mainTip, 3)
+
+	sideParent := makeOutputOnlyTestBlock(
+		2,
+		commonAncestor.Hash(),
+		commonAncestor.Header.Timestamp+2*BlockIntervalSec,
+		[]TxOutput{{PublicKey: sidePub, Commitment: sideComm}},
+	)
+
+	sideParentHash := sideParent.Hash()
+
+	chain.mu.Lock()
+	defer chain.mu.Unlock()
+	chain.blocks[sideParentHash] = sideParent
+
+	checker, err := chain.branchAwareRingMemberCheckerLocked(sideParentHash)
+	if err != nil {
+		t.Fatalf("failed to construct branch-aware ring checker: %v", err)
+	}
+
+	if !checker(commonPub, commonComm) {
+		t.Fatal("expected common-ancestor output to remain canonical for the candidate branch")
+	}
+	if checker(mainPub, mainComm) {
+		t.Fatal("expected divergent main-chain output above the fork point to be ignored")
+	}
+	if !checker(sidePub, sideComm) {
+		t.Fatal("expected side-branch ancestor output to be canonical for the candidate branch")
+	}
+	if checker(unrelatedPub, unrelatedComm) {
+		t.Fatal("expected unrelated output to not be canonical for the candidate branch")
+	}
+}
+
+func TestValidateBlockWithContext_AcceptsSideBranchRingMembers(t *testing.T) {
+	chain, storage, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	genesis := chain.GetBlockByHeight(0)
+	if genesis == nil {
+		t.Fatal("expected genesis block")
+	}
+
+	spendTx := mustBuildValidRingCTBindingTestTx(t)
+
+	var commonPub, commonComm [32]byte
+	commonPub[0] = 0x51
+	commonComm[0] = 0x52
+
+	var mainPub, mainComm [32]byte
+	mainPub[0] = 0x61
+	mainComm[0] = 0x62
+
+	commonAncestor := makeOutputOnlyTestBlock(
+		1,
+		genesis.Hash(),
+		genesis.Header.Timestamp+BlockIntervalSec,
+		[]TxOutput{{PublicKey: commonPub, Commitment: commonComm}},
+	)
+	commitMainChainBlockForTest(t, chain, storage, commonAncestor, 2)
+
+	mainTip := makeOutputOnlyTestBlock(
+		2,
+		commonAncestor.Hash(),
+		commonAncestor.Header.Timestamp+BlockIntervalSec,
+		[]TxOutput{{PublicKey: mainPub, Commitment: mainComm}},
+	)
+	commitMainChainBlockForTest(t, chain, storage, mainTip, 3)
+
+	sideOutputs := make([]TxOutput, len(spendTx.Inputs[0].RingMembers))
+	for i := range spendTx.Inputs[0].RingMembers {
+		sideOutputs[i] = TxOutput{
+			PublicKey:  spendTx.Inputs[0].RingMembers[i],
+			Commitment: spendTx.Inputs[0].RingCommitments[i],
+		}
+	}
+	sideParent := makeOutputOnlyTestBlock(
+		2,
+		commonAncestor.Hash(),
+		commonAncestor.Header.Timestamp+2*BlockIntervalSec,
+		sideOutputs,
+	)
+	sideParentHash := sideParent.Hash()
+
+	keys, err := GenerateStealthKeys()
+	if err != nil {
+		t.Fatalf("failed to generate coinbase keys: %v", err)
+	}
+	coinbase, err := CreateCoinbase(keys.SpendPubKey, keys.ViewPubKey, GetBlockReward(3), 3)
+	if err != nil {
+		t.Fatalf("failed to create coinbase: %v", err)
+	}
+
+	candidate := &Block{
+		Header: BlockHeader{
+			Version:    1,
+			Height:     3,
+			PrevHash:   sideParentHash,
+			Timestamp:  sideParent.Header.Timestamp + BlockIntervalSec,
+			Difficulty: MinDifficulty,
+		},
+		Transactions: []*Transaction{coinbase.Tx, spendTx},
+	}
+	merkleRoot, err := candidate.ComputeMerkleRoot()
+	if err != nil {
+		t.Fatalf("failed to compute merkle root: %v", err)
+	}
+	candidate.Header.MerkleRoot = merkleRoot
+
+	chain.mu.Lock()
+	defer chain.mu.Unlock()
+	chain.blocks[sideParentHash] = sideParent
+
+	spentChecker, err := chain.branchAwareSpentCheckerLocked(sideParentHash)
+	if err != nil {
+		t.Fatalf("failed to construct branch-aware spent checker: %v", err)
+	}
+
+	if err := validateBlockWithContext(
+		candidate,
+		chain.bestHash,
+		chain.height,
+		chain.getBlockByHashLocked,
+		spentChecker,
+		chain.isCanonicalRingMemberLocked,
+		true,
+	); err == nil || !strings.Contains(err.Error(), "not a canonical on-chain output") {
+		t.Fatalf("expected current canonical checker to reject side-branch ring members, got: %v", err)
+	}
+
+	ringChecker, err := chain.branchAwareRingMemberCheckerLocked(sideParentHash)
+	if err != nil {
+		t.Fatalf("failed to construct branch-aware ring checker: %v", err)
+	}
+
+	if err := validateBlockWithContext(
+		candidate,
+		chain.bestHash,
+		chain.height,
+		chain.getBlockByHashLocked,
+		spentChecker,
+		ringChecker,
+		true,
+	); err != nil {
+		t.Fatalf("expected branch-aware ring checker to accept side-branch block, got: %v", err)
+	}
+}


### PR DESCRIPTION
This fixes the remaining branch-context validation bug for competing forks. Block processing was already using a branch-aware spent-key-image check, but ring-member validation still relied on the current canonical output set, which could make a valid side-branch block fail as not a canonical on-chain output during reorg/sync.

  The patch makes ring-member canonicality branch-aware during ProcessBlock validation by scoping accepted outputs to the candidate branch plus canonical outputs at or below the common ancestor. It also adds regressions covering both the helper itself and the end-to-end case where the old checker rejects a valid side-branch block while the new checker accepts it.
