### PR TITLE
Optimize ring member selection

### DIFF
--- a/block.go
+++ b/block.go
@@ -2452,11 +2452,6 @@ func (c *Chain) GetAllOutputs() ([]*UTXO, error) {
 
 // SelectRingMembersWithCommitments selects ring members for a transaction input
 func (c *Chain) SelectRingMembersWithCommitments(realPubKey, realCommitment [32]byte) (*RingMemberData, error) {
-	allOutputs, err := c.storage.GetAllOutputs()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get outputs: %w", err)
-	}
-
 	ringSize := RingSize
 
 	// Fast path: iterate under the read lock using the pre-built index.
@@ -2464,15 +2459,7 @@ func (c *Chain) SelectRingMembersWithCommitments(realPubKey, realCommitment [32]
 	// locked rebuild + scan below.
 	c.mu.RLock()
 	if c.canonicalRingMemberIndexUsableRLocked() {
-		decoyPool := make([]*UTXO, 0, len(allOutputs))
-		for _, utxo := range allOutputs {
-			if utxo.Output.PublicKey == realPubKey {
-				continue
-			}
-			if _, ok := c.canonicalRingIndex[canonicalRingIndexKey(utxo.Output.PublicKey, utxo.Output.Commitment)]; ok {
-				decoyPool = append(decoyPool, utxo)
-			}
-		}
+		decoyPool := canonicalRingIndexDecoys(c.canonicalRingIndex, realPubKey)
 		c.mu.RUnlock()
 		return finalizeRingSelection(decoyPool, realPubKey, realCommitment, ringSize)
 	}
@@ -2485,24 +2472,40 @@ func (c *Chain) SelectRingMembersWithCommitments(realPubKey, realCommitment [32]
 		c.mu.Unlock()
 		return nil, fmt.Errorf("failed to build canonical ring-member index: %w", err)
 	}
-	decoyPool := make([]*UTXO, 0, len(allOutputs))
-	for _, utxo := range allOutputs {
-		if utxo.Output.PublicKey == realPubKey {
-			continue
-		}
-		if _, ok := c.canonicalRingIndex[canonicalRingIndexKey(utxo.Output.PublicKey, utxo.Output.Commitment)]; ok {
-			decoyPool = append(decoyPool, utxo)
-		}
-	}
+	decoyPool := canonicalRingIndexDecoys(c.canonicalRingIndex, realPubKey)
 	c.mu.Unlock()
 
 	return finalizeRingSelection(decoyPool, realPubKey, realCommitment, ringSize)
 }
 
+type ringMemberCandidate struct {
+	publicKey  [32]byte
+	commitment [32]byte
+}
+
+func canonicalRingIndexDecoys(index map[[64]byte]struct{}, realPubKey [32]byte) []ringMemberCandidate {
+	decoys := make([]ringMemberCandidate, 0, len(index))
+	for key := range index {
+		candidate := ringMemberCandidateFromIndexKey(key)
+		if candidate.publicKey == realPubKey {
+			continue
+		}
+		decoys = append(decoys, candidate)
+	}
+	return decoys
+}
+
+func ringMemberCandidateFromIndexKey(key [64]byte) ringMemberCandidate {
+	var candidate ringMemberCandidate
+	copy(candidate.publicKey[:], key[:32])
+	copy(candidate.commitment[:], key[32:])
+	return candidate
+}
+
 // finalizeRingSelection shuffles the decoy pool and assembles the ring with
 // the real key at a randomly-chosen secret index. It does NOT touch chain
 // state, so callers can release c.mu before invoking it.
-func finalizeRingSelection(decoyPool []*UTXO, realPubKey, realCommitment [32]byte, ringSize int) (*RingMemberData, error) {
+func finalizeRingSelection(decoyPool []ringMemberCandidate, realPubKey, realCommitment [32]byte, ringSize int) (*RingMemberData, error) {
 	if len(decoyPool) < ringSize-1 {
 		return nil, fmt.Errorf("not enough outputs for ring (need %d, have %d)", ringSize-1, len(decoyPool))
 	}
@@ -2533,8 +2536,8 @@ func finalizeRingSelection(decoyPool []*UTXO, realPubKey, realCommitment [32]byt
 			keys[i] = realPubKey
 			commitments[i] = realCommitment
 		} else {
-			keys[i] = decoys[decoyIdx].Output.PublicKey
-			commitments[i] = decoys[decoyIdx].Output.Commitment
+			keys[i] = decoys[decoyIdx].publicKey
+			commitments[i] = decoys[decoyIdx].commitment
 			decoyIdx++
 		}
 	}

--- a/block_ring_selection_benchmark_test.go
+++ b/block_ring_selection_benchmark_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkSelectRingMembersWithCommitments(b *testing.B) {
+	for _, outputCount := range []int{64, 1024, 8192, 65536} {
+		b.Run(fmt.Sprintf("outputs_%d", outputCount), func(b *testing.B) {
+			chain, storage := newRingSelectionBenchmarkChain(b)
+			defer func() {
+				if err := chain.Close(); err != nil {
+					b.Fatalf("failed to close chain: %v", err)
+				}
+			}()
+
+			genesis := chain.GetBlockByHeight(0)
+			if genesis == nil {
+				b.Fatal("expected genesis block")
+			}
+
+			outputs := make([]TxOutput, outputCount)
+			for i := range outputs {
+				outputs[i] = TxOutput{
+					PublicKey:  ringSelectionBenchmarkKey(byte(0x10), uint64(i)),
+					Commitment: ringSelectionBenchmarkKey(byte(0x20), uint64(i)),
+				}
+			}
+
+			block := &Block{
+				Header: BlockHeader{
+					Version:    1,
+					Height:     1,
+					PrevHash:   genesis.Hash(),
+					Timestamp:  genesis.Header.Timestamp + BlockIntervalSec,
+					Difficulty: MinDifficulty,
+				},
+				Transactions: []*Transaction{
+					{
+						Version: 1,
+						Outputs: outputs,
+					},
+				},
+			}
+			commitRingSelectionBenchmarkBlock(b, chain, storage, block)
+
+			realPubKey := outputs[0].PublicKey
+			realCommitment := outputs[0].Commitment
+			if _, err := chain.SelectRingMembersWithCommitments(realPubKey, realCommitment); err != nil {
+				b.Fatalf("warmup ring selection failed: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := chain.SelectRingMembersWithCommitments(realPubKey, realCommitment); err != nil {
+					b.Fatalf("ring selection failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func newRingSelectionBenchmarkChain(b *testing.B) (*Chain, *Storage) {
+	b.Helper()
+
+	chain, err := NewChain(b.TempDir())
+	if err != nil {
+		b.Fatalf("failed to create chain: %v", err)
+	}
+	genesis, err := GetGenesisBlock()
+	if err != nil {
+		b.Fatalf("failed to load genesis block: %v", err)
+	}
+	if err := chain.addGenesisBlock(genesis); err != nil {
+		b.Fatalf("failed to add genesis block: %v", err)
+	}
+	return chain, chain.Storage()
+}
+
+func commitRingSelectionBenchmarkBlock(b *testing.B, chain *Chain, storage *Storage, block *Block) {
+	b.Helper()
+
+	txID, err := block.Transactions[0].TxID()
+	if err != nil {
+		b.Fatalf("failed to hash tx: %v", err)
+	}
+	newOutputs := make([]*UTXO, 0, len(block.Transactions[0].Outputs))
+	for idx, out := range block.Transactions[0].Outputs {
+		newOutputs = append(newOutputs, &UTXO{
+			TxID:        txID,
+			OutputIndex: uint32(idx),
+			Output:      out,
+			BlockHeight: block.Header.Height,
+		})
+	}
+
+	hash := block.Hash()
+	work := uint64(2)
+	if err := storage.CommitBlock(&BlockCommit{
+		Block:      block,
+		Height:     block.Header.Height,
+		Hash:       hash,
+		Work:       work,
+		IsMainTip:  true,
+		NewOutputs: newOutputs,
+	}); err != nil {
+		b.Fatalf("failed to commit block: %v", err)
+	}
+
+	chain.mu.Lock()
+	defer chain.mu.Unlock()
+	chain.blocks[hash] = block
+	chain.workAt[hash] = work
+	chain.byHeight[block.Header.Height] = hash
+	chain.bestHash = hash
+	chain.height = block.Header.Height
+	chain.totalWork = work
+	chain.canonicalRingIndexDirty = true
+}
+
+func ringSelectionBenchmarkKey(prefix byte, n uint64) [32]byte {
+	var key [32]byte
+	key[0] = prefix
+	binary.LittleEndian.PutUint64(key[8:], n)
+	return key
+}


### PR DESCRIPTION
## Summary
This speeds up wallet transaction construction by avoiding a full storage scan for every ring member selection.

Before this change, each selected input loaded and JSON-decoded every stored output from BoltDB, then filtered those outputs through the canonical ring index. With many inputs, that repeated scan dominated transaction build time.

This change builds the decoy pool directly from the in-memory canonical ring index, then releases the chain lock before shuffling and final ring assembly.

## Speedup
Local benchmark results for one ring selection:

```text
outputs   before      after       speedup
64        ~0.61ms     ~0.006ms    ~100x
1,024     ~11.1ms     ~0.079ms    ~140x
8,192     ~82.7ms     ~0.71ms     ~116x
65,536    ~656ms      ~6.5ms      ~100x
```

Full no-broadcast transaction build benchmark with a 23,500-output synthetic chain:

```text
inputs   before      after
1        ~288ms      ~49ms
4        ~1.01s      ~57ms
16       ~4.00s      ~95ms
28       ~7.03s      ~135ms
```
