### PR TITLE
Repair noncanonical wallet outputs

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -1487,6 +1487,17 @@ func (s *APIServer) handleLoadWallet(w http.ResponseWriter, r *http.Request) {
 		walletHeight = wl.SyncedHeight()
 	}
 
+	if issues := repairableWalletOutputIssues(auditWalletCanonicalOutputs(s.daemon.Chain(), wl.AllOutputs()), false); len(issues) > 0 {
+		removed := removeWalletOutputIssues(wl, issues)
+		if len(removed) > 0 {
+			log.Printf("Wallet load: removed %d noncanonical wallet output(s) totaling %d atomic units", len(removed), sumOwnedOutputs(removed))
+			if err := wl.Save(); err != nil {
+				writeInternal(w, r, http.StatusInternalServerError, "internal error", err)
+				return
+			}
+		}
+	}
+
 	wl.SetInputFilter(func(out *wallet.OwnedOutput) bool {
 		ki, err := GenerateKeyImage(out.OneTimePrivKey)
 		if err != nil {
@@ -1994,6 +2005,51 @@ func (s *APIServer) handleAudit(w http.ResponseWriter, r *http.Request) {
 		"duplicate_groups":  duplicates,
 		"total_burned":      totalBurned,
 		"burned_outputs":    burnedOutputs,
+	})
+}
+
+// handleWalletOutputsAudit checks wallet outputs against the canonical chain.
+// POST /api/wallet/outputs/audit
+func (s *APIServer) handleWalletOutputsAudit(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWallet(w, r) {
+		return
+	}
+
+	var req struct {
+		Repair bool `json:"repair"`
+	}
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+	}
+
+	outputs := s.wallet.AllOutputs()
+	issues := auditWalletCanonicalOutputs(s.daemon.Chain(), outputs)
+
+	removedCount := 0
+	var removedAmount uint64
+	if req.Repair {
+		removed := removeWalletOutputIssues(s.wallet, issues)
+		removedCount = len(removed)
+		removedAmount = sumOwnedOutputs(removed)
+		if removedCount > 0 {
+			if err := s.wallet.Save(); err != nil {
+				writeInternal(w, r, http.StatusInternalServerError, "internal error", err)
+				return
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"total_outputs":   len(outputs),
+		"stale_outputs":   len(issues),
+		"stale_amount":    sumCanonicalOutputIssues(issues),
+		"repaired":        req.Repair,
+		"removed_outputs": removedCount,
+		"removed_amount":  removedAmount,
+		"issues":          issues,
 	})
 }
 

--- a/api_openapi.json
+++ b/api_openapi.json
@@ -2225,6 +2225,127 @@
         }
       }
     },
+    "/api/wallet/outputs/audit": {
+      "post": {
+        "operationId": "auditWalletOutputs",
+        "tags": ["Wallet"],
+        "summary": "Audit wallet outputs against the canonical chain",
+        "description": "Checks each wallet output against the canonical block at its recorded height. Reports outputs whose transaction, output index, public key, or commitment no longer matches the canonical chain. Set repair=true to remove reported outputs from the wallet file. Requires loaded, unlocked wallet.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "repair": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, remove reported noncanonical outputs and save the wallet."
+                  }
+                }
+              },
+              "example": { "repair": true }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Canonical output audit results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total_outputs": { "type": "integer" },
+                    "stale_outputs": { "type": "integer" },
+                    "stale_amount": {
+                      "type": "integer",
+                      "description": "Total amount in reported stale outputs, in atomic units"
+                    },
+                    "repaired": { "type": "boolean" },
+                    "removed_outputs": { "type": "integer" },
+                    "removed_amount": {
+                      "type": "integer",
+                      "description": "Total amount removed from the wallet, in atomic units"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "txid": { "type": "string" },
+                          "output_index": { "type": "integer" },
+                          "amount": { "type": "integer" },
+                          "spent": { "type": "boolean" },
+                          "block_height": { "type": "integer" },
+                          "reason": {
+                            "type": "string",
+                            "enum": [
+                              "missing_canonical_block",
+                              "tx_not_in_canonical_block",
+                              "output_index_out_of_range",
+                              "output_public_key_mismatch",
+                              "output_commitment_mismatch",
+                              "negative_output_index"
+                            ]
+                          },
+                          "canonical_block_hash": { "type": "string" },
+                          "one_time_pub": { "type": "string" },
+                          "commitment": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "total_outputs": 12,
+                  "stale_outputs": 1,
+                  "stale_amount": 100000000,
+                  "repaired": true,
+                  "removed_outputs": 1,
+                  "removed_amount": 100000000,
+                  "issues": [
+                    {
+                      "txid": "b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4",
+                      "output_index": 0,
+                      "amount": 100000000,
+                      "spent": false,
+                      "block_height": 1200,
+                      "reason": "tx_not_in_canonical_block",
+                      "canonical_block_hash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+                      "one_time_pub": "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+                      "commitment": "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" },
+                "example": { "error": "invalid JSON body" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/WalletLocked" },
+          "500": {
+            "description": "Wallet repair could not be saved",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" },
+                "example": { "error": "internal error" }
+              }
+            }
+          },
+          "503": { "$ref": "#/components/responses/NoWallet" }
+        }
+      }
+    },
     "/api/wallet/viewkeys": {
       "post": {
         "operationId": "getViewKeys",

--- a/api_routes.go
+++ b/api_routes.go
@@ -40,6 +40,7 @@ func (s *APIServer) registerPrivateRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/wallet/sync", s.handleWalletSync)
 	mux.HandleFunc("POST /api/wallet/prove", s.handleProve)
 	mux.HandleFunc("POST /api/wallet/audit", s.handleAudit)
+	mux.HandleFunc("POST /api/wallet/outputs/audit", s.handleWalletOutputsAudit)
 	mux.HandleFunc("POST /api/wallet/viewkeys", s.handleViewKeys)
 
 	// Chain verification

--- a/cli.go
+++ b/cli.go
@@ -510,6 +510,18 @@ func (c *CLI) recoverWalletAfterChainReset() {
 			}
 		}
 	}
+
+	issues := repairableWalletOutputIssues(auditWalletCanonicalOutputs(c.daemon.Chain(), c.wallet.AllOutputs()), false)
+	removed := removeWalletOutputIssues(c.wallet, issues)
+	if len(removed) == 0 {
+		return
+	}
+
+	fmt.Printf("  Chain repair: removed %d noncanonical wallet outputs totaling %s\n",
+		len(removed), formatAmount(sumOwnedOutputs(removed)))
+	if err := c.wallet.Save(); err != nil {
+		fmt.Printf("  Warning: failed to persist wallet output repair: %v\n", err)
+	}
 }
 
 func (c *CLI) printLogo() {

--- a/wallet/remove_outputs_test.go
+++ b/wallet/remove_outputs_test.go
@@ -1,0 +1,47 @@
+package wallet
+
+import "testing"
+
+func TestRemoveOutputsRemovesMatchesAndReservations(t *testing.T) {
+	txid1 := [32]byte{0x01}
+	txid2 := [32]byte{0x02}
+	txid3 := [32]byte{0x03}
+
+	w := &Wallet{
+		data: WalletData{
+			Outputs: []*OwnedOutput{
+				{TxID: txid1, OutputIndex: 0, Amount: 100, Memo: []byte{0x01, 0x02}},
+				{TxID: txid2, OutputIndex: 1, Amount: 200},
+				{TxID: txid3, OutputIndex: 2, Amount: 300},
+			},
+		},
+		inputReservations: map[reservedOutpoint]inputReservation{
+			{TxID: txid1, OutputIndex: 0}: {},
+			{TxID: txid2, OutputIndex: 1}: {},
+		},
+	}
+
+	removed := w.RemoveOutputs([]OutputRef{
+		{TxID: txid1, OutputIndex: 0},
+		{TxID: txid2, OutputIndex: 1},
+		{TxID: [32]byte{0xff}, OutputIndex: 9},
+	})
+
+	if len(removed) != 2 {
+		t.Fatalf("expected 2 removed outputs, got %d", len(removed))
+	}
+	if len(w.data.Outputs) != 1 || w.data.Outputs[0].TxID != txid3 {
+		t.Fatalf("unexpected kept outputs: %#v", w.data.Outputs)
+	}
+	if _, ok := w.inputReservations[reservedOutpoint{TxID: txid1, OutputIndex: 0}]; ok {
+		t.Fatal("expected reservation for removed output 1 to be cleared")
+	}
+	if _, ok := w.inputReservations[reservedOutpoint{TxID: txid2, OutputIndex: 1}]; ok {
+		t.Fatal("expected reservation for removed output 2 to be cleared")
+	}
+
+	removed[0].Memo[0] = 0xff
+	if w.data.Outputs[0].Amount != 300 {
+		t.Fatalf("kept output was mutated: %#v", w.data.Outputs[0])
+	}
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1187,6 +1187,60 @@ type OutputRef struct {
 	OutputIndex int
 }
 
+// RemoveOutputs removes wallet outputs matching the supplied refs and returns
+// snapshots of the removed entries. Missing refs are ignored.
+func (w *Wallet) RemoveOutputs(refs []OutputRef) []*OwnedOutput {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	type outKey struct {
+		txID   [32]byte
+		outIdx int
+	}
+	remove := make(map[outKey]struct{}, len(refs))
+	for _, ref := range refs {
+		remove[outKey{ref.TxID, ref.OutputIndex}] = struct{}{}
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	kept := w.data.Outputs[:0]
+	removed := make([]*OwnedOutput, 0, len(refs))
+	for _, out := range w.data.Outputs {
+		if out == nil {
+			kept = append(kept, out)
+			continue
+		}
+		k := outKey{out.TxID, out.OutputIndex}
+		if _, ok := remove[k]; !ok {
+			kept = append(kept, out)
+			continue
+		}
+
+		c := *out
+		if len(out.Memo) > 0 {
+			c.Memo = append([]byte(nil), out.Memo...)
+		} else {
+			c.Memo = nil
+		}
+		removed = append(removed, &c)
+
+		if w.inputReservations != nil {
+			delete(w.inputReservations, reservedOutpoint{TxID: out.TxID, OutputIndex: out.OutputIndex})
+		}
+	}
+
+	if len(kept) == 0 {
+		w.data.Outputs = nil
+	} else {
+		w.data.Outputs = kept
+	}
+
+	return removed
+}
+
 // ReserveSpecificInputs validates and reserves caller-specified outputs (coin control).
 // Returns granular errors identifying which output failed and why.
 func (w *Wallet) ReserveSpecificInputs(refs []OutputRef, currentHeight uint64, ttl time.Duration) (lease uint64, inputs []*OwnedOutput, err error) {

--- a/wallet_output_audit.go
+++ b/wallet_output_audit.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/hex"
+
+	"blocknet/wallet"
+)
+
+const (
+	walletOutputIssueMissingBlock       = "missing_canonical_block"
+	walletOutputIssueMissingTx          = "tx_not_in_canonical_block"
+	walletOutputIssueIndexOutOfRange    = "output_index_out_of_range"
+	walletOutputIssuePublicKeyMismatch  = "output_public_key_mismatch"
+	walletOutputIssueCommitmentMismatch = "output_commitment_mismatch"
+	walletOutputIssueNegativeIndex      = "negative_output_index"
+)
+
+type walletCanonicalOutputIssue struct {
+	Ref                wallet.OutputRef `json:"-"`
+	TxID               string           `json:"txid"`
+	OutputIndex        int              `json:"output_index"`
+	Amount             uint64           `json:"amount"`
+	Spent              bool             `json:"spent"`
+	BlockHeight        uint64           `json:"block_height"`
+	Reason             string           `json:"reason"`
+	CanonicalBlockHash string           `json:"canonical_block_hash,omitempty"`
+	OneTimePub         string           `json:"one_time_pub"`
+	Commitment         string           `json:"commitment"`
+}
+
+func auditWalletCanonicalOutputs(chain *Chain, outputs []*wallet.OwnedOutput) []walletCanonicalOutputIssue {
+	if chain == nil || len(outputs) == 0 {
+		return nil
+	}
+
+	issues := make([]walletCanonicalOutputIssue, 0)
+	for _, out := range outputs {
+		if out == nil {
+			continue
+		}
+		if issue, ok := auditWalletCanonicalOutput(chain, out); ok {
+			issues = append(issues, issue)
+		}
+	}
+	return issues
+}
+
+func auditWalletCanonicalOutput(chain *Chain, out *wallet.OwnedOutput) (walletCanonicalOutputIssue, bool) {
+	base := walletCanonicalOutputIssue{
+		Ref:         wallet.OutputRef{TxID: out.TxID, OutputIndex: out.OutputIndex},
+		TxID:        hex.EncodeToString(out.TxID[:]),
+		OutputIndex: out.OutputIndex,
+		Amount:      out.Amount,
+		Spent:       out.Spent,
+		BlockHeight: out.BlockHeight,
+		OneTimePub:  hex.EncodeToString(out.OneTimePubKey[:]),
+		Commitment:  hex.EncodeToString(out.Commitment[:]),
+	}
+
+	if out.OutputIndex < 0 {
+		base.Reason = walletOutputIssueNegativeIndex
+		return base, true
+	}
+
+	block := chain.GetBlockByHeight(out.BlockHeight)
+	if block == nil {
+		base.Reason = walletOutputIssueMissingBlock
+		return base, true
+	}
+	blockHash := block.Hash()
+	base.CanonicalBlockHash = hex.EncodeToString(blockHash[:])
+
+	for i := range block.Transactions {
+		tx := block.Transactions[i]
+		if tx == nil {
+			continue
+		}
+		txID, err := tx.TxID()
+		if err != nil || txID != out.TxID {
+			continue
+		}
+		if out.OutputIndex >= len(tx.Outputs) {
+			base.Reason = walletOutputIssueIndexOutOfRange
+			return base, true
+		}
+		txOut := tx.Outputs[out.OutputIndex]
+		if txOut.PublicKey != out.OneTimePubKey {
+			base.Reason = walletOutputIssuePublicKeyMismatch
+			return base, true
+		}
+		if txOut.Commitment != out.Commitment {
+			base.Reason = walletOutputIssueCommitmentMismatch
+			return base, true
+		}
+		return walletCanonicalOutputIssue{}, false
+	}
+
+	base.Reason = walletOutputIssueMissingTx
+	return base, true
+}
+
+func repairableWalletOutputIssues(issues []walletCanonicalOutputIssue, includeMissingBlocks bool) []walletCanonicalOutputIssue {
+	if len(issues) == 0 {
+		return nil
+	}
+
+	repairable := make([]walletCanonicalOutputIssue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.Reason == walletOutputIssueMissingBlock && !includeMissingBlocks {
+			continue
+		}
+		repairable = append(repairable, issue)
+	}
+	return repairable
+}
+
+func removeWalletOutputIssues(w *wallet.Wallet, issues []walletCanonicalOutputIssue) []*wallet.OwnedOutput {
+	if w == nil || len(issues) == 0 {
+		return nil
+	}
+
+	refs := make([]wallet.OutputRef, len(issues))
+	for i, issue := range issues {
+		refs[i] = issue.Ref
+	}
+	return w.RemoveOutputs(refs)
+}
+
+func sumCanonicalOutputIssues(issues []walletCanonicalOutputIssue) uint64 {
+	var total uint64
+	for _, issue := range issues {
+		total += issue.Amount
+	}
+	return total
+}
+
+func sumOwnedOutputs(outputs []*wallet.OwnedOutput) uint64 {
+	var total uint64
+	for _, out := range outputs {
+		if out != nil {
+			total += out.Amount
+		}
+	}
+	return total
+}

--- a/wallet_output_audit_test.go
+++ b/wallet_output_audit_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"blocknet/wallet"
+)
+
+func TestAuditWalletCanonicalOutputsDetectsStaleOutputs(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	pub := [32]byte{0x10}
+	commitment := [32]byte{0x20}
+	tx := Transaction{
+		Version: 1,
+		Outputs: []TxOutput{{
+			PublicKey:  pub,
+			Commitment: commitment,
+		}},
+	}
+	txID, err := tx.TxID()
+	if err != nil {
+		t.Fatalf("failed to compute txid: %v", err)
+	}
+	addSyntheticCanonicalBlock(t, chain, 1, []*Transaction{&tx})
+
+	issues := auditWalletCanonicalOutputs(chain, []*wallet.OwnedOutput{
+		{TxID: txID, OutputIndex: 0, Amount: 10, BlockHeight: 1, OneTimePubKey: pub, Commitment: commitment},
+		{TxID: [32]byte{0x99}, OutputIndex: 0, Amount: 20, BlockHeight: 1, OneTimePubKey: pub, Commitment: commitment},
+		{TxID: txID, OutputIndex: 2, Amount: 30, BlockHeight: 1, OneTimePubKey: pub, Commitment: commitment},
+		{TxID: txID, OutputIndex: 0, Amount: 40, BlockHeight: 1, OneTimePubKey: [32]byte{0x11}, Commitment: commitment},
+		{TxID: txID, OutputIndex: 0, Amount: 50, BlockHeight: 1, OneTimePubKey: pub, Commitment: [32]byte{0x21}},
+		{TxID: txID, OutputIndex: 0, Amount: 60, BlockHeight: 99, OneTimePubKey: pub, Commitment: commitment},
+		{TxID: txID, OutputIndex: -1, Amount: 70, BlockHeight: 1, OneTimePubKey: pub, Commitment: commitment},
+	})
+
+	wantReasons := map[string]bool{
+		walletOutputIssueMissingTx:          false,
+		walletOutputIssueIndexOutOfRange:    false,
+		walletOutputIssuePublicKeyMismatch:  false,
+		walletOutputIssueCommitmentMismatch: false,
+		walletOutputIssueMissingBlock:       false,
+		walletOutputIssueNegativeIndex:      false,
+	}
+	if len(issues) != len(wantReasons) {
+		t.Fatalf("expected %d issues, got %d: %#v", len(wantReasons), len(issues), issues)
+	}
+	for _, issue := range issues {
+		if _, ok := wantReasons[issue.Reason]; !ok {
+			t.Fatalf("unexpected issue reason %q: %#v", issue.Reason, issue)
+		}
+		wantReasons[issue.Reason] = true
+	}
+	for reason, seen := range wantReasons {
+		if !seen {
+			t.Fatalf("missing issue reason %q", reason)
+		}
+	}
+}
+
+func TestHandleWalletOutputsAuditCanRepairStaleOutputs(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	pub := [32]byte{0x30}
+	commitment := [32]byte{0x40}
+	tx := Transaction{
+		Version: 1,
+		Outputs: []TxOutput{{
+			PublicKey:  pub,
+			Commitment: commitment,
+		}},
+	}
+	txID, err := tx.TxID()
+	if err != nil {
+		t.Fatalf("failed to compute txid: %v", err)
+	}
+	addSyntheticCanonicalBlock(t, chain, 1, []*Transaction{&tx})
+
+	d, stop := mustStartTestDaemon(t, chain)
+	defer stop()
+
+	walletFile := t.TempDir() + "/wallet.dat"
+	w, err := wallet.NewWallet(walletFile, []byte("pw"), defaultWalletConfig())
+	if err != nil {
+		t.Fatalf("failed to create wallet: %v", err)
+	}
+	w.AddOutput(&wallet.OwnedOutput{
+		TxID:          txID,
+		OutputIndex:   0,
+		Amount:        10,
+		BlockHeight:   1,
+		OneTimePubKey: pub,
+		Commitment:    commitment,
+	})
+	w.AddOutput(&wallet.OwnedOutput{
+		TxID:          [32]byte{0x99},
+		OutputIndex:   0,
+		Amount:        20,
+		BlockHeight:   1,
+		OneTimePubKey: pub,
+		Commitment:    commitment,
+	})
+
+	s := NewAPIServer(d, w, nil, t.TempDir(), []byte("pw"))
+	resp := mustMakeHTTPJSONRequest(
+		t,
+		http.HandlerFunc(s.handleWalletOutputsAudit),
+		http.MethodPost,
+		"/api/wallet/outputs/audit",
+		[]byte(`{"repair":true}`),
+		map[string]string{"Content-Type": "application/json"},
+	)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if got := int(body["stale_outputs"].(float64)); got != 1 {
+		t.Fatalf("expected stale_outputs=1, got %d (%v)", got, body)
+	}
+	if got := int(body["removed_outputs"].(float64)); got != 1 {
+		t.Fatalf("expected removed_outputs=1, got %d (%v)", got, body)
+	}
+	if got := uint64(body["removed_amount"].(float64)); got != 20 {
+		t.Fatalf("expected removed_amount=20, got %d (%v)", got, body)
+	}
+
+	total, unspent := w.OutputCount()
+	if total != 1 || unspent != 1 {
+		t.Fatalf("expected one valid output after repair, got total=%d unspent=%d", total, unspent)
+	}
+}
+
+func TestRecoverWalletAfterChainResetPrunesDeepNonCanonicalOutputs(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	pub := [32]byte{0x50}
+	commitment := [32]byte{0x60}
+	tx := Transaction{
+		Version: 1,
+		Outputs: []TxOutput{{
+			PublicKey:  pub,
+			Commitment: commitment,
+		}},
+	}
+	addSyntheticCanonicalBlock(t, chain, 1, []*Transaction{&tx})
+
+	chain.mu.Lock()
+	chain.height = 3
+	chain.mu.Unlock()
+
+	d, stop := mustStartTestDaemon(t, chain)
+	defer stop()
+
+	walletFile := t.TempDir() + "/wallet.dat"
+	w, err := wallet.NewWallet(walletFile, []byte("pw"), defaultWalletConfig())
+	if err != nil {
+		t.Fatalf("failed to create wallet: %v", err)
+	}
+	w.AddOutput(&wallet.OwnedOutput{
+		TxID:          [32]byte{0x99},
+		OutputIndex:   0,
+		Amount:        20,
+		BlockHeight:   1,
+		OneTimePubKey: pub,
+		Commitment:    commitment,
+	})
+	w.SetSyncedHeight(3)
+
+	c := &CLI{wallet: w, daemon: d, noColor: true}
+	c.recoverWalletAfterChainReset()
+
+	total, unspent := w.OutputCount()
+	if total != 0 || unspent != 0 {
+		t.Fatalf("expected stale deep output to be removed, got total=%d unspent=%d", total, unspent)
+	}
+}
+
+func addSyntheticCanonicalBlock(t *testing.T, chain *Chain, height uint64, txs []*Transaction) {
+	t.Helper()
+
+	prev := chain.GetBlockByHeight(height - 1)
+	if prev == nil {
+		t.Fatalf("missing previous block at height %d", height-1)
+	}
+	block := &Block{
+		Header: BlockHeader{
+			Version:    1,
+			Height:     height,
+			PrevHash:   prev.Hash(),
+			Timestamp:  prev.Header.Timestamp + BlockIntervalSec,
+			Difficulty: MinDifficulty,
+		},
+		Transactions: txs,
+	}
+	hash := block.Hash()
+
+	chain.mu.Lock()
+	chain.blocks[hash] = block
+	chain.byHeight[height] = hash
+	if chain.height < height {
+		chain.height = height
+	}
+	chain.mu.Unlock()
+}


### PR DESCRIPTION
## Summary
- add canonical-chain auditing for wallet outputs by block height, txid, output index, one-time pubkey, and commitment
- add POST /api/wallet/outputs/audit with optional {"repair":true} removal and OpenAPI docs
- conservatively remove noncanonical outputs during wallet load/startup while leaving missing-block cases for explicit repair

## Tests
- cargo build --release (crypto-rs)
- go test ./wallet
- go test -run 'TestOpenAPI|TestAuditWalletCanonicalOutputs|TestHandleWalletOutputsAudit|TestRecoverWalletAfterChainReset|TestHandleLoadWallet_ReorgAtSameHeight' .\n\nNote: go test ./... still hits existing P2P test failures in this environment: several tests fail with "failed to dial: dial to self attempted" before this patch-specific code is involved.