### PR TITLE
Serve mining templates during near-tip sync runs

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -24,6 +24,13 @@ import (
 const (
 	sendMinFee     = uint64(1000) // 0.00001 BNT minimum fee
 	sendFeePerByte = uint64(10)   // 0.0000001 BNT per byte
+
+	// blockTemplateSyncHeightTolerance is how many blocks behind an active
+	// sync target the local tip may be while still serving mining templates.
+	// Near-tip sync runs (propagation races, overlap re-downloads) finish in
+	// seconds and do not make templates meaningfully stale; hard-failing them
+	// starves pools of work for the whole run.
+	blockTemplateSyncHeightTolerance = uint64(2)
 )
 
 // ============================================================================
@@ -2161,7 +2168,7 @@ func (s *APIServer) handleBlockTemplate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if s.daemon.syncMgr.IsSyncing() {
+	if s.daemon.syncMgr.IsSyncingFarBehind(blockTemplateSyncHeightTolerance) {
 		writeError(w, http.StatusServiceUnavailable, "node is syncing")
 		return
 	}

--- a/p2p/sync.go
+++ b/p2p/sync.go
@@ -1292,6 +1292,29 @@ func (sm *SyncManager) IsSyncing() bool {
 	return sm.syncing
 }
 
+// IsSyncingFarBehind reports whether an active sync run is targeting a tip
+// more than tolerance blocks ahead of the local chain. Any peer that briefly
+// advertises more cumulative work — for example after losing a propagation
+// race by fractions of a second — triggers a sync run that re-downloads a
+// small overlap window and the mempool, holding IsSyncing true for many
+// seconds even though the local tip is current the whole time. Callers that
+// only need to avoid acting on a genuinely stale chain (such as mining
+// template serving) should use this instead of IsSyncing.
+func (sm *SyncManager) IsSyncingFarBehind(tolerance uint64) bool {
+	sm.mu.RLock()
+	syncing := sm.syncing
+	target := sm.syncTarget
+	sm.mu.RUnlock()
+	if !syncing {
+		return false
+	}
+	// Compare against the live chain tip rather than syncProgress: the
+	// overlap re-download makes syncProgress regress below the tip, while
+	// the tip itself only moves forward.
+	height := sm.getStatus().Height
+	return target > height && target-height > tolerance
+}
+
 // SyncProgress returns sync progress info (current, target, elapsed)
 func (sm *SyncManager) SyncProgress() (uint64, uint64, time.Duration) {
 	sm.mu.RLock()

--- a/p2p/sync_far_behind_test.go
+++ b/p2p/sync_far_behind_test.go
@@ -1,0 +1,63 @@
+package p2p
+
+import (
+	"sync"
+	"testing"
+)
+
+func newFarBehindTestManager(tipHeight uint64) *SyncManager {
+	return &SyncManager{
+		mu:        sync.RWMutex{},
+		getStatus: func() ChainStatus { return ChainStatus{Height: tipHeight} },
+	}
+}
+
+func TestIsSyncingFarBehindNotSyncing(t *testing.T) {
+	sm := newFarBehindTestManager(100)
+	if sm.IsSyncingFarBehind(2) {
+		t.Fatal("not syncing should never report far behind")
+	}
+}
+
+func TestIsSyncingFarBehindNearTip(t *testing.T) {
+	sm := newFarBehindTestManager(100)
+	sm.syncing = true
+	sm.syncTarget = 101
+
+	if sm.IsSyncingFarBehind(2) {
+		t.Fatal("one-block catch-up should stay within tolerance")
+	}
+}
+
+func TestIsSyncingFarBehindAtTargetDuringMempoolPhase(t *testing.T) {
+	sm := newFarBehindTestManager(101)
+	sm.syncing = true
+	sm.syncTarget = 101
+
+	if sm.IsSyncingFarBehind(0) {
+		t.Fatal("tip at target should not report far behind even with zero tolerance")
+	}
+}
+
+func TestIsSyncingFarBehindDeepSync(t *testing.T) {
+	sm := newFarBehindTestManager(100)
+	sm.syncing = true
+	sm.syncTarget = 500
+
+	if !sm.IsSyncingFarBehind(2) {
+		t.Fatal("deep sync must report far behind")
+	}
+}
+
+func TestIsSyncingFarBehindExactTolerance(t *testing.T) {
+	sm := newFarBehindTestManager(100)
+	sm.syncing = true
+	sm.syncTarget = 102
+
+	if sm.IsSyncingFarBehind(2) {
+		t.Fatal("gap equal to tolerance should still serve templates")
+	}
+	if !sm.IsSyncingFarBehind(1) {
+		t.Fatal("gap above tolerance must report far behind")
+	}
+}


### PR DESCRIPTION
Any peer that briefly advertises more cumulative work — typically after losing a block propagation race by fractions of a second — triggers a sync run that re-downloads a ~10 block overlap window plus the mempool. IsSyncing stays true for the entire run (10-20s), during which /api/mining/blocktemplate hard-fails with 503 "node is syncing" even though the local tip is current the whole time. Pools poll for a fresh template at exactly that moment (the SSE new_block event for the same block), so every propagation race starves miners of the new template for the length of the sync run.

Add SyncManager.IsSyncingFarBehind, which compares the active sync target against the live chain tip, and use it in handleBlockTemplate with a 2-block tolerance. Deep syncs still refuse to serve stale templates; near-tip catch-up runs keep serving work. Sync scheduling itself is unchanged — the node still always converges on the heaviest advertised chain.

<img width="1620" height="662" alt="image" src="https://github.com/user-attachments/assets/de71879f-dfde-4b07-ac88-c05b3b15e02a" />
