### PR TITLE
Add renewable mining template leases

### DIFF
--- a/api_blocktemplate_reward_address_test.go
+++ b/api_blocktemplate_reward_address_test.go
@@ -274,6 +274,12 @@ func TestHandleBlockTemplate_LiveSameTipCacheFullReturns503(t *testing.T) {
 	if resp["error"] != want {
 		t.Fatalf("unexpected cache-full error: got %q want %q", resp["error"], want)
 	}
+	if got := resp["code"]; got != "mining_template_cache_full" {
+		t.Fatalf("unexpected cache-full code: got %q", got)
+	}
+	if got := rr.Header().Get("Retry-After"); got != "3600" {
+		t.Fatalf("unexpected Retry-After header: got %q want %q", got, "3600")
+	}
 	if len(api.templateCache) != maxMiningTemplateCacheEntries {
 		t.Fatalf("cache size changed on rejected template: got %d", len(api.templateCache))
 	}

--- a/api_blocktemplate_reward_address_test.go
+++ b/api_blocktemplate_reward_address_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"blocknet/p2p"
 	"blocknet/wallet"
@@ -78,6 +79,9 @@ func TestHandleBlockTemplate_RewardAddressOverrideAlternates(t *testing.T) {
 	}
 
 	api := NewAPIServer(daemon, wA, nil, t.TempDir(), []byte("pw"))
+	templateNow := time.Date(2026, time.July, 10, 12, 0, 0, 0, time.UTC)
+	api.templateNow = func() time.Time { return templateNow }
+	api.templateTTL = 90 * time.Second
 	mux := http.NewServeMux()
 	api.registerPublicRoutes(mux)
 	api.registerPrivateRoutes(mux)
@@ -101,10 +105,12 @@ func TestHandleBlockTemplate_RewardAddressOverrideAlternates(t *testing.T) {
 	scannerB := wallet.NewScanner(wB, defaultScannerConfig())
 
 	type resp struct {
-		Block             *Block  `json:"block"`
-		RewardAddressUsed string  `json:"reward_address_used"`
-		Target            string  `json:"target"`
-		HeaderBase        string  `json:"header_base"`
+		Block                       *Block `json:"block"`
+		RewardAddressUsed           string `json:"reward_address_used"`
+		Target                      string `json:"target"`
+		HeaderBase                  string `json:"header_base"`
+		TemplateID                  string `json:"template_id"`
+		TemplateExpiresAtUnixMillis int64  `json:"template_expires_at_unix_ms"`
 	}
 
 	// Default: pays to wallet A (loaded wallet)
@@ -122,6 +128,12 @@ func TestHandleBlockTemplate_RewardAddressOverrideAlternates(t *testing.T) {
 		}
 		if got.RewardAddressUsed != wA.Address() {
 			t.Fatalf("reward_address_used mismatch: got %q want %q", got.RewardAddressUsed, wA.Address())
+		}
+		if got.TemplateID == "" {
+			t.Fatal("expected non-empty template_id")
+		}
+		if want := templateNow.Add(api.templateTTL).UnixMilli(); got.TemplateExpiresAtUnixMillis != want {
+			t.Fatalf("template expiry mismatch: got %d want %d", got.TemplateExpiresAtUnixMillis, want)
 		}
 
 		foundA, _ := scannerA.ScanBlock(mustBlockToWalletScanData(t, got.Block))
@@ -218,4 +230,3 @@ func TestHandleBlockTemplate_InvalidAddressOverrideReturns400(t *testing.T) {
 		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
-

--- a/api_blocktemplate_reward_address_test.go
+++ b/api_blocktemplate_reward_address_test.go
@@ -230,3 +230,51 @@ func TestHandleBlockTemplate_InvalidAddressOverrideReturns400(t *testing.T) {
 		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
+
+func TestHandleBlockTemplate_LiveSameTipCacheFullReturns503(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	daemon, stopDaemon := mustStartTestDaemon(t, chain)
+	defer stopDaemon()
+	daemon.syncMgr = new(p2p.SyncManager)
+
+	walletFile := filepath.Join(t.TempDir(), "wallet.dat")
+	w, err := wallet.NewWallet(walletFile, []byte("pw"), defaultWalletConfig())
+	if err != nil {
+		t.Fatalf("failed to create wallet: %v", err)
+	}
+
+	api := NewAPIServer(daemon, w, nil, t.TempDir(), []byte("pw"))
+	now := time.Date(2026, time.July, 10, 19, 0, 0, 0, time.UTC)
+	api.templateNow = func() time.Time { return now }
+	api.templateTTL = time.Hour
+
+	tip := chain.TemplateParams()
+	cached := &Block{Header: BlockHeader{Version: 1, Height: tip.Height, PrevHash: tip.PrevHash}}
+	for i := 0; i < maxMiningTemplateCacheEntries; i++ {
+		if _, _, err := api.rememberMiningTemplateLease(cached); err != nil {
+			t.Fatalf("fill template cache at entry %d: %v", i, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mining/blocktemplate", nil)
+	rr := httptest.NewRecorder()
+	api.handleBlockTemplate(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	const want = "mining template cache full, retry after a lease expires or the chain tip changes"
+	if resp["error"] != want {
+		t.Fatalf("unexpected cache-full error: got %q want %q", resp["error"], want)
+	}
+	if len(api.templateCache) != maxMiningTemplateCacheEntries {
+		t.Fatalf("cache size changed on rejected template: got %d", len(api.templateCache))
+	}
+}

--- a/api_handlers.go
+++ b/api_handlers.go
@@ -2279,11 +2279,14 @@ func (s *APIServer) handleBlockTemplate(w http.ResponseWriter, r *http.Request) 
 	target := DifficultyToTarget(block.Header.Difficulty)
 	templateID, expiresAt, err := s.rememberMiningTemplateLease(block)
 	if err != nil {
-		if errors.Is(err, errMiningTemplateCacheFull) {
+		switch {
+		case errors.Is(err, errMiningTemplateCacheFull):
 			writeError(w, http.StatusServiceUnavailable, "mining template cache full, retry after a lease expires or the chain tip changes")
-			return
+		case errors.Is(err, errMiningTemplateStale):
+			writeError(w, http.StatusServiceUnavailable, "chain tip changed while building template, retry")
+		default:
+			writeInternal(w, r, http.StatusInternalServerError, "internal error", err)
 		}
-		writeInternal(w, r, http.StatusInternalServerError, "internal error", err)
 		return
 	}
 

--- a/api_handlers.go
+++ b/api_handlers.go
@@ -2277,7 +2277,15 @@ func (s *APIServer) handleBlockTemplate(w http.ResponseWriter, r *http.Request) 
 
 	// Compute target for PoW validation
 	target := DifficultyToTarget(block.Header.Difficulty)
-	templateID, expiresAt := s.rememberMiningTemplateLease(block)
+	templateID, expiresAt, err := s.rememberMiningTemplateLease(block)
+	if err != nil {
+		if errors.Is(err, errMiningTemplateCacheFull) {
+			writeError(w, http.StatusServiceUnavailable, "mining template cache full, retry after a lease expires or the chain tip changes")
+			return
+		}
+		writeInternal(w, r, http.StatusInternalServerError, "internal error", err)
+		return
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"block":                       block,

--- a/api_handlers.go
+++ b/api_handlers.go
@@ -2281,9 +2281,13 @@ func (s *APIServer) handleBlockTemplate(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		switch {
 		case errors.Is(err, errMiningTemplateCacheFull):
-			writeError(w, http.StatusServiceUnavailable, "mining template cache full, retry after a lease expires or the chain tip changes")
+			var capacityErr *miningTemplateCacheFullError
+			if errors.As(err, &capacityErr) {
+				w.Header().Set("Retry-After", strconv.FormatInt(capacityErr.retryAfterSeconds, 10))
+			}
+			writeCodedError(w, http.StatusServiceUnavailable, "mining_template_cache_full", "mining template cache full, retry after a lease expires or the chain tip changes")
 		case errors.Is(err, errMiningTemplateStale):
-			writeError(w, http.StatusServiceUnavailable, "chain tip changed while building template, retry")
+			writeCodedError(w, http.StatusServiceUnavailable, "mining_template_tip_changed", "chain tip changed while building template, retry")
 		default:
 			writeInternal(w, r, http.StatusInternalServerError, "internal error", err)
 		}
@@ -2552,6 +2556,12 @@ func encodeJSONResponse(v any) ([]byte, error) {
 // writeError writes a JSON error response.
 func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// writeCodedError adds a stable machine-readable code while preserving the
+// existing human-readable error field for backward-compatible clients.
+func writeCodedError(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, map[string]string{"code": code, "error": msg})
 }
 
 // writeInternal logs err server-side and returns a generic client-facing error.

--- a/api_handlers.go
+++ b/api_handlers.go
@@ -2277,14 +2277,52 @@ func (s *APIServer) handleBlockTemplate(w http.ResponseWriter, r *http.Request) 
 
 	// Compute target for PoW validation
 	target := DifficultyToTarget(block.Header.Difficulty)
-	templateID := s.rememberMiningTemplate(block)
+	templateID, expiresAt := s.rememberMiningTemplateLease(block)
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"block":               block,
-		"target":              fmt.Sprintf("%x", target),
-		"header_base":         fmt.Sprintf("%x", block.Header.SerializeForPoW()),
-		"reward_address_used": rewardAddrUsed,
-		"template_id":         templateID,
+		"block":                       block,
+		"target":                      fmt.Sprintf("%x", target),
+		"header_base":                 fmt.Sprintf("%x", block.Header.SerializeForPoW()),
+		"reward_address_used":         rewardAddrUsed,
+		"template_id":                 templateID,
+		"template_expires_at_unix_ms": expiresAt.UnixMilli(),
+	})
+}
+
+// handleRenewBlockTemplate extends the compact-submission lease for a template
+// that is still live and still builds directly on the current canonical tip.
+// POST /api/mining/renewtemplate
+func (s *APIServer) handleRenewBlockTemplate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TemplateID string `json:"template_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	templateID := strings.TrimSpace(req.TemplateID)
+	if templateID == "" {
+		writeError(w, http.StatusBadRequest, "template_id is required")
+		return
+	}
+
+	expiresAt, err := s.renewMiningTemplate(templateID)
+	if err != nil {
+		switch {
+		case errors.Is(err, errMiningTemplateUnavailable):
+			writeError(w, http.StatusNotFound, "unknown or expired template_id")
+		case errors.Is(err, errMiningTemplateStale):
+			writeError(w, http.StatusConflict, "template no longer builds on current tip")
+		default:
+			writeInternal(w, r, http.StatusInternalServerError, "internal error", err)
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"template_id":                 templateID,
+		"template_expires_at_unix_ms": expiresAt.UnixMilli(),
 	})
 }
 

--- a/api_mining_openapi_contract_test.go
+++ b/api_mining_openapi_contract_test.go
@@ -57,11 +57,19 @@ func TestOpenAPIMiningTemplateLeaseAndCompactSubmitContract(t *testing.T) {
 	unavailableContent := mustGetMapAny(t, blockTemplateUnavailable, "content")
 	unavailableJSON := mustGetMapAny(t, unavailableContent, "application/json")
 	unavailableExamples := mustGetMapAny(t, unavailableJSON, "examples")
-	if _, ok := unavailableExamples["lease_capacity"]; !ok {
-		t.Fatal("blocktemplate 503 contract missing lease_capacity example")
+	leaseCapacity := mustGetMapAny(t, unavailableExamples, "lease_capacity")
+	leaseCapacityValue := mustGetMapAny(t, leaseCapacity, "value")
+	if got := leaseCapacityValue["code"]; got != "mining_template_cache_full" {
+		t.Fatalf("blocktemplate capacity code mismatch: got %#v", got)
 	}
-	if _, ok := unavailableExamples["tip_changed"]; !ok {
-		t.Fatal("blocktemplate 503 contract missing tip_changed example")
+	tipChanged := mustGetMapAny(t, unavailableExamples, "tip_changed")
+	tipChangedValue := mustGetMapAny(t, tipChanged, "value")
+	if got := tipChangedValue["code"]; got != "mining_template_tip_changed" {
+		t.Fatalf("blocktemplate tip-change code mismatch: got %#v", got)
+	}
+	unavailableHeaders := mustGetMapAny(t, blockTemplateUnavailable, "headers")
+	if _, ok := unavailableHeaders["Retry-After"]; !ok {
+		t.Fatal("blocktemplate 503 contract missing Retry-After header")
 	}
 
 	renewPath := mustGetMapAny(t, paths, "/api/mining/renewtemplate")

--- a/api_mining_openapi_contract_test.go
+++ b/api_mining_openapi_contract_test.go
@@ -50,6 +50,17 @@ func TestOpenAPIMiningTemplateLeaseAndCompactSubmitContract(t *testing.T) {
 	}
 
 	paths := mustGetMapAny(t, spec, "paths")
+	blockTemplatePath := mustGetMapAny(t, paths, "/api/mining/blocktemplate")
+	blockTemplateGet := mustGetMapAny(t, blockTemplatePath, "get")
+	blockTemplateResponses := mustGetMapAny(t, blockTemplateGet, "responses")
+	blockTemplateUnavailable := mustGetMapAny(t, blockTemplateResponses, "503")
+	unavailableContent := mustGetMapAny(t, blockTemplateUnavailable, "content")
+	unavailableJSON := mustGetMapAny(t, unavailableContent, "application/json")
+	unavailableExamples := mustGetMapAny(t, unavailableJSON, "examples")
+	if _, ok := unavailableExamples["lease_capacity"]; !ok {
+		t.Fatal("blocktemplate 503 contract missing lease_capacity example")
+	}
+
 	renewPath := mustGetMapAny(t, paths, "/api/mining/renewtemplate")
 	renewPost := mustGetMapAny(t, renewPath, "post")
 	renewBody := mustGetMapAny(t, renewPost, "requestBody")

--- a/api_mining_openapi_contract_test.go
+++ b/api_mining_openapi_contract_test.go
@@ -60,6 +60,9 @@ func TestOpenAPIMiningTemplateLeaseAndCompactSubmitContract(t *testing.T) {
 	if _, ok := unavailableExamples["lease_capacity"]; !ok {
 		t.Fatal("blocktemplate 503 contract missing lease_capacity example")
 	}
+	if _, ok := unavailableExamples["tip_changed"]; !ok {
+		t.Fatal("blocktemplate 503 contract missing tip_changed example")
+	}
 
 	renewPath := mustGetMapAny(t, paths, "/api/mining/renewtemplate")
 	renewPost := mustGetMapAny(t, renewPath, "post")

--- a/api_mining_openapi_contract_test.go
+++ b/api_mining_openapi_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestOpenAPIMiningCompactSubmitContract(t *testing.T) {
+func TestOpenAPIMiningTemplateLeaseAndCompactSubmitContract(t *testing.T) {
 	specBytes, err := os.ReadFile("api_openapi.json")
 	if err != nil {
 		t.Fatalf("failed to read api_openapi.json: %v", err)
@@ -25,6 +25,20 @@ func TestOpenAPIMiningCompactSubmitContract(t *testing.T) {
 	if _, ok := blockTemplateProps["template_id"]; !ok {
 		t.Fatal("BlockTemplate schema missing template_id")
 	}
+	if _, ok := blockTemplateProps["template_expires_at_unix_ms"]; !ok {
+		t.Fatal("BlockTemplate schema missing template_expires_at_unix_ms")
+	}
+
+	renewRequest := mustGetMapAny(t, schemas, "RenewBlockTemplateRequest")
+	renewRequestProps := mustGetMapAny(t, renewRequest, "properties")
+	if _, ok := renewRequestProps["template_id"]; !ok {
+		t.Fatal("RenewBlockTemplateRequest missing template_id")
+	}
+	renewResponse := mustGetMapAny(t, schemas, "RenewBlockTemplateResponse")
+	renewResponseProps := mustGetMapAny(t, renewResponse, "properties")
+	if _, ok := renewResponseProps["template_expires_at_unix_ms"]; !ok {
+		t.Fatal("RenewBlockTemplateResponse missing template_expires_at_unix_ms")
+	}
 
 	compactSubmit := mustGetMapAny(t, schemas, "CompactSubmitBlock")
 	compactProps := mustGetMapAny(t, compactSubmit, "properties")
@@ -36,6 +50,22 @@ func TestOpenAPIMiningCompactSubmitContract(t *testing.T) {
 	}
 
 	paths := mustGetMapAny(t, spec, "paths")
+	renewPath := mustGetMapAny(t, paths, "/api/mining/renewtemplate")
+	renewPost := mustGetMapAny(t, renewPath, "post")
+	renewBody := mustGetMapAny(t, renewPost, "requestBody")
+	renewContent := mustGetMapAny(t, renewBody, "content")
+	renewJSON := mustGetMapAny(t, renewContent, "application/json")
+	renewSchema := mustGetMapAny(t, renewJSON, "schema")
+	if got := renewSchema["$ref"]; got != "#/components/schemas/RenewBlockTemplateRequest" {
+		t.Fatalf("renewtemplate request schema mismatch: got %#v", got)
+	}
+	renewResponses := mustGetMapAny(t, renewPost, "responses")
+	for _, status := range []string{"200", "400", "401", "404", "409"} {
+		if _, ok := renewResponses[status]; !ok {
+			t.Fatalf("renewtemplate responses missing status %s", status)
+		}
+	}
+
 	submitPath := mustGetMapAny(t, paths, "/api/mining/submitblock")
 	submitPost := mustGetMapAny(t, submitPath, "post")
 	requestBody := mustGetMapAny(t, submitPost, "requestBody")

--- a/api_openapi.json
+++ b/api_openapi.json
@@ -2739,7 +2739,13 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "503": {
-            "description": "A template cannot currently be served because no wallet is loaded, the node is syncing, the chain tip changed during construction, or all 512 same-tip lease slots are live",
+            "description": "A template cannot currently be served because no wallet is loaded, the node is syncing, the chain tip changed during construction, or all 512 same-tip lease slots are live. Capacity responses include Retry-After with the number of seconds until the earliest lease expiry.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the earliest live template lease expires. Present for mining_template_cache_full responses.",
+                "schema": { "type": "integer", "minimum": 1 }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Error" },
@@ -2751,10 +2757,16 @@
                     "value": { "error": "node is syncing" }
                   },
                   "tip_changed": {
-                    "value": { "error": "chain tip changed while building template, retry" }
+                    "value": {
+                      "code": "mining_template_tip_changed",
+                      "error": "chain tip changed while building template, retry"
+                    }
                   },
                   "lease_capacity": {
-                    "value": { "error": "mining template cache full, retry after a lease expires or the chain tip changes" }
+                    "value": {
+                      "code": "mining_template_cache_full",
+                      "error": "mining template cache full, retry after a lease expires or the chain tip changes"
+                    }
                   }
                 }
               }
@@ -3002,6 +3014,10 @@
         "type": "object",
         "required": ["error"],
         "properties": {
+          "code": {
+            "type": "string",
+            "description": "Optional stable machine-readable error code. Clients should prefer this over matching the human-readable error string when present."
+          },
           "error": {
             "type": "string",
             "description": "Human-readable error message"

--- a/api_openapi.json
+++ b/api_openapi.json
@@ -2695,7 +2695,7 @@
         "operationId": "getBlockTemplate",
         "tags": ["Mining"],
         "summary": "Get block template for pool mining",
-        "description": "Returns a complete block template ready for proof-of-work solving. Includes a pre-built coinbase transaction (paying to the loaded wallet by default, or to the optional `address` override), selected mempool transactions, and the computed merkle root. The `target` field (hex) is the PoW target that the Argon2id hash must be less than. The `header_base` field (hex) is the 92-byte serialized header without the nonce, used as input to the PoW hash function. The `template_id` field identifies this template and can be used with compact submit payloads (`template_id` + `nonce`) via `POST /api/mining/submitblock`. Its compact-submission lease expires at `template_expires_at_unix_ms`; clients may extend a live, current-tip lease with `POST /api/mining/renewtemplate`. Requires a loaded wallet (for coinbase keys) but does not require it to be unlocked.",
+        "description": "Returns a complete block template ready for proof-of-work solving. Includes a pre-built coinbase transaction (paying to the loaded wallet by default, or to the optional `address` override), selected mempool transactions, and the computed merkle root. The `target` field (hex) is the PoW target that the Argon2id hash must be less than. The `header_base` field (hex) is the 92-byte serialized header without the nonce, used as input to the PoW hash function. The `template_id` field identifies this template and can be used with compact submit payloads (`template_id` + `nonce`) via `POST /api/mining/submitblock`. Its compact-submission lease expires at `template_expires_at_unix_ms`; clients may extend a live, current-tip lease with `POST /api/mining/renewtemplate`. The daemon retains at most 512 live leases for one tip and returns 503 rather than evicting a lease before its advertised expiry. Requires a loaded wallet (for coinbase keys) but does not require it to be unlocked.",
         "parameters": [
           {
             "name": "address",
@@ -2738,7 +2738,25 @@
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
-          "503": { "$ref": "#/components/responses/NoWallet" }
+          "503": {
+            "description": "A template cannot currently be served because no wallet is loaded, the node is syncing, or all 512 same-tip lease slots are live",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" },
+                "examples": {
+                  "no_wallet": {
+                    "value": { "error": "no wallet loaded" }
+                  },
+                  "syncing": {
+                    "value": { "error": "node is syncing" }
+                  },
+                  "lease_capacity": {
+                    "value": { "error": "mining template cache full, retry after a lease expires or the chain tip changes" }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/api_openapi.json
+++ b/api_openapi.json
@@ -2739,7 +2739,7 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "503": {
-            "description": "A template cannot currently be served because no wallet is loaded, the node is syncing, or all 512 same-tip lease slots are live",
+            "description": "A template cannot currently be served because no wallet is loaded, the node is syncing, the chain tip changed during construction, or all 512 same-tip lease slots are live",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Error" },
@@ -2749,6 +2749,9 @@
                   },
                   "syncing": {
                     "value": { "error": "node is syncing" }
+                  },
+                  "tip_changed": {
+                    "value": { "error": "chain tip changed while building template, retry" }
                   },
                   "lease_capacity": {
                     "value": { "error": "mining template cache full, retry after a lease expires or the chain tip changes" }

--- a/api_openapi.json
+++ b/api_openapi.json
@@ -2695,7 +2695,7 @@
         "operationId": "getBlockTemplate",
         "tags": ["Mining"],
         "summary": "Get block template for pool mining",
-        "description": "Returns a complete block template ready for proof-of-work solving. Includes a pre-built coinbase transaction (paying to the loaded wallet by default, or to the optional `address` override), selected mempool transactions, and the computed merkle root. The `target` field (hex) is the PoW target that the Argon2id hash must be less than. The `header_base` field (hex) is the 92-byte serialized header without the nonce, used as input to the PoW hash function. The `template_id` field identifies this template and can be used with compact submit payloads (`template_id` + `nonce`) via `POST /api/mining/submitblock`. Requires a loaded wallet (for coinbase keys) but does not require it to be unlocked.",
+        "description": "Returns a complete block template ready for proof-of-work solving. Includes a pre-built coinbase transaction (paying to the loaded wallet by default, or to the optional `address` override), selected mempool transactions, and the computed merkle root. The `target` field (hex) is the PoW target that the Argon2id hash must be less than. The `header_base` field (hex) is the 92-byte serialized header without the nonce, used as input to the PoW hash function. The `template_id` field identifies this template and can be used with compact submit payloads (`template_id` + `nonce`) via `POST /api/mining/submitblock`. Its compact-submission lease expires at `template_expires_at_unix_ms`; clients may extend a live, current-tip lease with `POST /api/mining/renewtemplate`. Requires a loaded wallet (for coinbase keys) but does not require it to be unlocked.",
         "parameters": [
           {
             "name": "address",
@@ -2730,7 +2730,8 @@
                   "target": "000000000000f4240000000000000000000000000000000000000000000000000",
                   "header_base": "0100000080370000...",
                   "reward_address_used": "3wZc3y1Qw4eYpZtGJxkqkV6xG9c2oXHqfJjQ6b3sR5hYhJ8tZz1qvJ1mY1a9o7hV4pYwqH7xG5d5d8cJ8p4",
-                  "template_id": "7b3d2f4a9d11c8ef"
+                  "template_id": "7b3d2f4a9d11c8ef",
+                  "template_expires_at_unix_ms": 1738800840000
                 }
               }
             }
@@ -2738,6 +2739,57 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "503": { "$ref": "#/components/responses/NoWallet" }
+        }
+      }
+    },
+    "/api/mining/renewtemplate": {
+      "post": {
+        "operationId": "renewBlockTemplate",
+        "tags": ["Mining"],
+        "summary": "Renew a block-template lease",
+        "description": "Extends the compact-submission lease of an unexpired cached template. Renewal succeeds only while the template still builds directly on the current canonical chain tip. This does not rebuild or otherwise change the template.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/RenewBlockTemplateRequest" },
+              "example": { "template_id": "7b3d2f4a9d11c8ef" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Template lease renewed",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RenewBlockTemplateResponse" },
+                "example": {
+                  "template_id": "7b3d2f4a9d11c8ef",
+                  "template_expires_at_unix_ms": 1738801140000
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": {
+            "description": "The template ID is unknown or its lease has expired",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" },
+                "example": { "error": "unknown or expired template_id" }
+              }
+            }
+          },
+          "409": {
+            "description": "The template no longer builds on the current canonical tip",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" },
+                "example": { "error": "template no longer builds on current tip" }
+              }
+            }
+          }
         }
       }
     },
@@ -3832,6 +3884,37 @@
           "template_id": {
             "type": "string",
             "description": "Opaque template identifier used for compact submit payloads (`template_id` + `nonce`)."
+          },
+          "template_expires_at_unix_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix timestamp in milliseconds when the compact-submission lease expires. Renew with POST /api/mining/renewtemplate before this instant to keep using the same template ID."
+          }
+        },
+        "required": ["block", "target", "header_base", "reward_address_used", "template_id", "template_expires_at_unix_ms"]
+      },
+      "RenewBlockTemplateRequest": {
+        "type": "object",
+        "required": ["template_id"],
+        "properties": {
+          "template_id": {
+            "type": "string",
+            "description": "Unexpired template ID returned by GET /api/mining/blocktemplate."
+          }
+        }
+      },
+      "RenewBlockTemplateResponse": {
+        "type": "object",
+        "required": ["template_id", "template_expires_at_unix_ms"],
+        "properties": {
+          "template_id": {
+            "type": "string",
+            "description": "The renewed template ID."
+          },
+          "template_expires_at_unix_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "New compact-submission lease expiry as a Unix timestamp in milliseconds."
           }
         }
       },

--- a/api_routes.go
+++ b/api_routes.go
@@ -55,6 +55,7 @@ func (s *APIServer) registerPrivateRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/mining/stop", s.handleMiningStop)
 	mux.HandleFunc("POST /api/mining/threads", s.handleMiningThreads)
 	mux.HandleFunc("GET /api/mining/blocktemplate", s.handleBlockTemplate)
+	mux.HandleFunc("POST /api/mining/renewtemplate", s.handleRenewBlockTemplate)
 	mux.HandleFunc("POST /api/mining/submitblock", s.handleSubmitBlock)
 
 	// Dangerous operations

--- a/api_server.go
+++ b/api_server.go
@@ -69,12 +69,13 @@ type APIServer struct {
 }
 
 type cachedMiningTemplate struct {
-	block         Block
-	lastTouchedAt time.Time
-	expiresAt     time.Time
+	block     Block
+	expiresAt time.Time
 }
 
 const (
+	// Never exceed this bound or evict an unexpired same-tip lease. New
+	// template requests fail until a lease expires or the chain tip changes.
 	maxMiningTemplateCacheEntries = 512
 	miningTemplateCacheTTL        = 10 * time.Minute
 )
@@ -232,52 +233,51 @@ func NewAPIServer(daemon *Daemon, w *wallet.Wallet, scanner *wallet.Scanner, dat
 	return s
 }
 
-func (s *APIServer) rememberMiningTemplate(block *Block) string {
-	templateID, _ := s.rememberMiningTemplateLease(block)
-	return templateID
+func (s *APIServer) rememberMiningTemplate(block *Block) (string, error) {
+	templateID, _, err := s.rememberMiningTemplateLease(block)
+	return templateID, err
 }
 
-func (s *APIServer) rememberMiningTemplateLease(block *Block) (string, time.Time) {
+func (s *APIServer) rememberMiningTemplateLease(block *Block) (string, time.Time, error) {
 	if block == nil {
-		return "", time.Time{}
+		return "", time.Time{}, errors.New("cannot cache nil mining template")
 	}
 	now := s.miningTemplateNow()
-
-	idBytes := make([]byte, 8)
-	if _, err := rand.Read(idBytes); err != nil {
-		nowNanos := now.UnixNano()
-		for i := 0; i < len(idBytes); i++ {
-			idBytes[i] = byte(nowNanos >> (8 * i))
-		}
-	}
-	templateID := hex.EncodeToString(idBytes)
 	expiresAt := now.Add(s.miningTemplateTTL())
 
 	s.templateMu.Lock()
 	defer s.templateMu.Unlock()
 
-	s.pruneMiningTemplatesLocked(now)
+	s.pruneMiningTemplatesForBlockLocked(now, block)
 	if s.templateCache == nil {
 		s.templateCache = make(map[string]cachedMiningTemplate)
 	}
-	s.templateCache[templateID] = cachedMiningTemplate{
-		block:         *block,
-		lastTouchedAt: now,
-		expiresAt:     expiresAt,
-	}
-	if len(s.templateCache) > maxMiningTemplateCacheEntries {
-		var oldestID string
-		var oldestTime time.Time
-		for id, tpl := range s.templateCache {
-			if oldestID == "" || tpl.lastTouchedAt.Before(oldestTime) {
-				oldestID = id
-				oldestTime = tpl.lastTouchedAt
-			}
-		}
-		delete(s.templateCache, oldestID)
+	if len(s.templateCache) >= maxMiningTemplateCacheEntries {
+		return "", time.Time{}, errMiningTemplateCacheFull
 	}
 
-	return templateID, expiresAt
+	var templateID string
+	for attempt := int64(0); ; attempt++ {
+		idBytes := make([]byte, 8)
+		if _, err := rand.Read(idBytes); err != nil {
+			fallback := now.UnixNano() + attempt
+			for i := 0; i < len(idBytes); i++ {
+				idBytes[i] = byte(fallback >> (8 * i))
+			}
+		}
+		candidate := hex.EncodeToString(idBytes)
+		if _, exists := s.templateCache[candidate]; !exists {
+			templateID = candidate
+			break
+		}
+	}
+
+	s.templateCache[templateID] = cachedMiningTemplate{
+		block:     *block,
+		expiresAt: expiresAt,
+	}
+
+	return templateID, expiresAt, nil
 }
 
 func (s *APIServer) getMiningTemplate(templateID string) (*Block, bool) {
@@ -299,6 +299,7 @@ func (s *APIServer) getMiningTemplate(templateID string) (*Block, bool) {
 }
 
 var (
+	errMiningTemplateCacheFull   = errors.New("mining template cache is full")
 	errMiningTemplateUnavailable = errors.New("mining template is unknown or expired")
 	errMiningTemplateStale       = errors.New("mining template does not build on the current tip")
 )
@@ -323,7 +324,6 @@ func (s *APIServer) renewMiningTemplate(templateID string) (time.Time, error) {
 		return time.Time{}, errMiningTemplateStale
 	}
 
-	tpl.lastTouchedAt = now
 	tpl.expiresAt = now.Add(s.miningTemplateTTL())
 	s.templateCache[templateID] = tpl
 	return tpl.expiresAt, nil
@@ -354,6 +354,16 @@ func (s *APIServer) miningTemplateTTL() time.Duration {
 func (s *APIServer) pruneMiningTemplatesLocked(now time.Time) {
 	for id, tpl := range s.templateCache {
 		if !now.Before(tpl.expiresAt) {
+			delete(s.templateCache, id)
+		}
+	}
+}
+
+func (s *APIServer) pruneMiningTemplatesForBlockLocked(now time.Time, block *Block) {
+	for id, tpl := range s.templateCache {
+		if !now.Before(tpl.expiresAt) ||
+			tpl.block.Header.Height != block.Header.Height ||
+			tpl.block.Header.PrevHash != block.Header.PrevHash {
 			delete(s.templateCache, id)
 		}
 	}

--- a/api_server.go
+++ b/api_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -63,11 +64,14 @@ type APIServer struct {
 	// Template cache for compact mining submissions ({template_id, nonce}).
 	templateMu    sync.Mutex
 	templateCache map[string]cachedMiningTemplate
+	templateNow   func() time.Time
+	templateTTL   time.Duration
 }
 
 type cachedMiningTemplate struct {
 	block     Block
 	createdAt time.Time
+	expiresAt time.Time
 }
 
 const (
@@ -229,26 +233,37 @@ func NewAPIServer(daemon *Daemon, w *wallet.Wallet, scanner *wallet.Scanner, dat
 }
 
 func (s *APIServer) rememberMiningTemplate(block *Block) string {
+	templateID, _ := s.rememberMiningTemplateLease(block)
+	return templateID
+}
+
+func (s *APIServer) rememberMiningTemplateLease(block *Block) (string, time.Time) {
 	if block == nil {
-		return ""
+		return "", time.Time{}
 	}
+	now := s.miningTemplateNow()
 
 	idBytes := make([]byte, 8)
 	if _, err := rand.Read(idBytes); err != nil {
-		now := time.Now().UnixNano()
+		nowNanos := now.UnixNano()
 		for i := 0; i < len(idBytes); i++ {
-			idBytes[i] = byte(now >> (8 * i))
+			idBytes[i] = byte(nowNanos >> (8 * i))
 		}
 	}
 	templateID := hex.EncodeToString(idBytes)
+	expiresAt := now.Add(s.miningTemplateTTL())
 
 	s.templateMu.Lock()
 	defer s.templateMu.Unlock()
 
-	s.pruneMiningTemplatesLocked(time.Now())
+	s.pruneMiningTemplatesLocked(now)
+	if s.templateCache == nil {
+		s.templateCache = make(map[string]cachedMiningTemplate)
+	}
 	s.templateCache[templateID] = cachedMiningTemplate{
 		block:     *block,
-		createdAt: time.Now(),
+		createdAt: now,
+		expiresAt: expiresAt,
 	}
 	if len(s.templateCache) > maxMiningTemplateCacheEntries {
 		var oldestID string
@@ -262,7 +277,7 @@ func (s *APIServer) rememberMiningTemplate(block *Block) string {
 		delete(s.templateCache, oldestID)
 	}
 
-	return templateID
+	return templateID, expiresAt
 }
 
 func (s *APIServer) getMiningTemplate(templateID string) (*Block, bool) {
@@ -270,7 +285,7 @@ func (s *APIServer) getMiningTemplate(templateID string) (*Block, bool) {
 		return nil, false
 	}
 
-	now := time.Now()
+	now := s.miningTemplateNow()
 	s.templateMu.Lock()
 	defer s.templateMu.Unlock()
 
@@ -283,9 +298,53 @@ func (s *APIServer) getMiningTemplate(templateID string) (*Block, bool) {
 	return &block, true
 }
 
+var (
+	errMiningTemplateUnavailable = errors.New("mining template is unknown or expired")
+	errMiningTemplateStale       = errors.New("mining template does not build on the current tip")
+)
+
+func (s *APIServer) renewMiningTemplate(templateID string) (time.Time, error) {
+	if templateID == "" {
+		return time.Time{}, errMiningTemplateUnavailable
+	}
+
+	now := s.miningTemplateNow()
+	s.templateMu.Lock()
+	defer s.templateMu.Unlock()
+
+	s.pruneMiningTemplatesLocked(now)
+	tpl, ok := s.templateCache[templateID]
+	if !ok {
+		return time.Time{}, errMiningTemplateUnavailable
+	}
+
+	tip := s.daemon.Chain().TemplateParams()
+	if tpl.block.Header.Height != tip.Height || tpl.block.Header.PrevHash != tip.PrevHash {
+		return time.Time{}, errMiningTemplateStale
+	}
+
+	tpl.expiresAt = now.Add(s.miningTemplateTTL())
+	s.templateCache[templateID] = tpl
+	return tpl.expiresAt, nil
+}
+
+func (s *APIServer) miningTemplateNow() time.Time {
+	if s.templateNow != nil {
+		return s.templateNow()
+	}
+	return time.Now()
+}
+
+func (s *APIServer) miningTemplateTTL() time.Duration {
+	if s.templateTTL > 0 {
+		return s.templateTTL
+	}
+	return miningTemplateCacheTTL
+}
+
 func (s *APIServer) pruneMiningTemplatesLocked(now time.Time) {
 	for id, tpl := range s.templateCache {
-		if now.Sub(tpl.createdAt) > miningTemplateCacheTTL {
+		if !now.Before(tpl.expiresAt) {
 			delete(s.templateCache, id)
 		}
 	}

--- a/api_server.go
+++ b/api_server.go
@@ -69,9 +69,9 @@ type APIServer struct {
 }
 
 type cachedMiningTemplate struct {
-	block     Block
-	createdAt time.Time
-	expiresAt time.Time
+	block         Block
+	lastTouchedAt time.Time
+	expiresAt     time.Time
 }
 
 const (
@@ -261,17 +261,17 @@ func (s *APIServer) rememberMiningTemplateLease(block *Block) (string, time.Time
 		s.templateCache = make(map[string]cachedMiningTemplate)
 	}
 	s.templateCache[templateID] = cachedMiningTemplate{
-		block:     *block,
-		createdAt: now,
-		expiresAt: expiresAt,
+		block:         *block,
+		lastTouchedAt: now,
+		expiresAt:     expiresAt,
 	}
 	if len(s.templateCache) > maxMiningTemplateCacheEntries {
 		var oldestID string
 		var oldestTime time.Time
 		for id, tpl := range s.templateCache {
-			if oldestID == "" || tpl.createdAt.Before(oldestTime) {
+			if oldestID == "" || tpl.lastTouchedAt.Before(oldestTime) {
 				oldestID = id
-				oldestTime = tpl.createdAt
+				oldestTime = tpl.lastTouchedAt
 			}
 		}
 		delete(s.templateCache, oldestID)
@@ -323,16 +323,25 @@ func (s *APIServer) renewMiningTemplate(templateID string) (time.Time, error) {
 		return time.Time{}, errMiningTemplateStale
 	}
 
+	tpl.lastTouchedAt = now
 	tpl.expiresAt = now.Add(s.miningTemplateTTL())
 	s.templateCache[templateID] = tpl
 	return tpl.expiresAt, nil
 }
 
 func (s *APIServer) miningTemplateNow() time.Time {
+	var now time.Time
 	if s.templateNow != nil {
-		return s.templateNow()
+		now = s.templateNow()
+	} else {
+		now = time.Now()
 	}
-	return time.Now()
+
+	// Lease deadlines are exposed as Unix milliseconds. Normalize both the
+	// production clock and injected test clocks to the same wall-clock basis so
+	// pruning happens exactly at the advertised instant, without Go's hidden
+	// monotonic component affecting comparisons.
+	return time.UnixMilli(now.UnixMilli()).In(now.Location())
 }
 
 func (s *APIServer) miningTemplateTTL() time.Duration {

--- a/api_server.go
+++ b/api_server.go
@@ -233,11 +233,6 @@ func NewAPIServer(daemon *Daemon, w *wallet.Wallet, scanner *wallet.Scanner, dat
 	return s
 }
 
-func (s *APIServer) rememberMiningTemplate(block *Block) (string, error) {
-	templateID, _, err := s.rememberMiningTemplateLease(block)
-	return templateID, err
-}
-
 func (s *APIServer) rememberMiningTemplateLease(block *Block) (string, time.Time, error) {
 	if block == nil {
 		return "", time.Time{}, errors.New("cannot cache nil mining template")
@@ -264,7 +259,9 @@ func (s *APIServer) rememberMiningTemplateLease(block *Block) (string, time.Time
 		s.templateCache = make(map[string]cachedMiningTemplate)
 	}
 	if len(s.templateCache) >= maxMiningTemplateCacheEntries {
-		return "", time.Time{}, errMiningTemplateCacheFull
+		return "", time.Time{}, &miningTemplateCacheFullError{
+			retryAfterSeconds: earliestMiningTemplateRetryAfterSeconds(s.templateCache, now),
+		}
 	}
 
 	var templateID string
@@ -315,6 +312,36 @@ var (
 	errMiningTemplateStale       = errors.New("mining template does not build on the current tip")
 )
 
+type miningTemplateCacheFullError struct {
+	retryAfterSeconds int64
+}
+
+func (e *miningTemplateCacheFullError) Error() string {
+	return errMiningTemplateCacheFull.Error()
+}
+
+func (e *miningTemplateCacheFullError) Unwrap() error {
+	return errMiningTemplateCacheFull
+}
+
+func earliestMiningTemplateRetryAfterSeconds(cache map[string]cachedMiningTemplate, now time.Time) int64 {
+	var earliest time.Time
+	for _, tpl := range cache {
+		if earliest.IsZero() || tpl.expiresAt.Before(earliest) {
+			earliest = tpl.expiresAt
+		}
+	}
+	if earliest.IsZero() || !earliest.After(now) {
+		return 1
+	}
+	remaining := earliest.Sub(now)
+	seconds := int64((remaining + time.Second - 1) / time.Second)
+	if seconds < 1 {
+		return 1
+	}
+	return seconds
+}
+
 func (s *APIServer) renewMiningTemplate(templateID string) (time.Time, error) {
 	if templateID == "" {
 		return time.Time{}, errMiningTemplateUnavailable
@@ -330,6 +357,9 @@ func (s *APIServer) renewMiningTemplate(templateID string) (time.Time, error) {
 		return time.Time{}, errMiningTemplateUnavailable
 	}
 
+	if s.daemon == nil || s.daemon.Chain() == nil {
+		return time.Time{}, errors.New("cannot renew mining template without chain state")
+	}
 	tip := s.daemon.Chain().TemplateParams()
 	if tpl.block.Header.Height != tip.Height || tpl.block.Header.PrevHash != tip.PrevHash {
 		return time.Time{}, errMiningTemplateStale

--- a/api_server.go
+++ b/api_server.go
@@ -242,11 +242,11 @@ func (s *APIServer) rememberMiningTemplateLease(block *Block) (string, time.Time
 	if block == nil {
 		return "", time.Time{}, errors.New("cannot cache nil mining template")
 	}
-	now := s.miningTemplateNow()
-	expiresAt := now.Add(s.miningTemplateTTL())
 
 	s.templateMu.Lock()
 	defer s.templateMu.Unlock()
+	now := s.miningTemplateNow()
+	expiresAt := now.Add(s.miningTemplateTTL())
 
 	if s.daemon == nil || s.daemon.Chain() == nil {
 		return "", time.Time{}, errors.New("cannot cache mining template without chain state")
@@ -296,9 +296,9 @@ func (s *APIServer) getMiningTemplate(templateID string) (*Block, bool) {
 		return nil, false
 	}
 
-	now := s.miningTemplateNow()
 	s.templateMu.Lock()
 	defer s.templateMu.Unlock()
+	now := s.miningTemplateNow()
 
 	s.pruneMiningTemplatesLocked(now)
 	tpl, ok := s.templateCache[templateID]
@@ -320,9 +320,9 @@ func (s *APIServer) renewMiningTemplate(templateID string) (time.Time, error) {
 		return time.Time{}, errMiningTemplateUnavailable
 	}
 
-	now := s.miningTemplateNow()
 	s.templateMu.Lock()
 	defer s.templateMu.Unlock()
+	now := s.miningTemplateNow()
 
 	s.pruneMiningTemplatesLocked(now)
 	tpl, ok := s.templateCache[templateID]

--- a/api_server.go
+++ b/api_server.go
@@ -248,7 +248,18 @@ func (s *APIServer) rememberMiningTemplateLease(block *Block) (string, time.Time
 	s.templateMu.Lock()
 	defer s.templateMu.Unlock()
 
-	s.pruneMiningTemplatesForBlockLocked(now, block)
+	if s.daemon == nil || s.daemon.Chain() == nil {
+		return "", time.Time{}, errors.New("cannot cache mining template without chain state")
+	}
+	// Snapshot canonical state only after winning the cache lock. An old request
+	// may have built its block before a tip change and then waited behind a newer
+	// request; reject it before it can prune the newer tip's advertised leases.
+	canonical := s.daemon.Chain().TemplateParams()
+	if block.Header.Height != canonical.Height || block.Header.PrevHash != canonical.PrevHash {
+		return "", time.Time{}, errMiningTemplateStale
+	}
+
+	s.pruneMiningTemplatesForTipLocked(now, canonical)
 	if s.templateCache == nil {
 		s.templateCache = make(map[string]cachedMiningTemplate)
 	}
@@ -359,11 +370,11 @@ func (s *APIServer) pruneMiningTemplatesLocked(now time.Time) {
 	}
 }
 
-func (s *APIServer) pruneMiningTemplatesForBlockLocked(now time.Time, block *Block) {
+func (s *APIServer) pruneMiningTemplatesForTipLocked(now time.Time, tip BlockTemplateParams) {
 	for id, tpl := range s.templateCache {
 		if !now.Before(tpl.expiresAt) ||
-			tpl.block.Header.Height != block.Header.Height ||
-			tpl.block.Header.PrevHash != block.Header.PrevHash {
+			tpl.block.Header.Height != tip.Height ||
+			tpl.block.Header.PrevHash != tip.PrevHash {
 			delete(s.templateCache, id)
 		}
 	}

--- a/api_submitblock_compact_test.go
+++ b/api_submitblock_compact_test.go
@@ -26,7 +26,10 @@ func TestHandleSubmitBlock_CompactPayloadUsesTemplateCache(t *testing.T) {
 			Nonce:    0,
 		},
 	}
-	templateID := s.rememberMiningTemplate(template)
+	templateID, err := s.rememberMiningTemplate(template)
+	if err != nil {
+		t.Fatalf("remember template: %v", err)
+	}
 	if templateID == "" {
 		t.Fatal("expected non-empty template id")
 	}

--- a/api_submitblock_compact_test.go
+++ b/api_submitblock_compact_test.go
@@ -42,7 +42,7 @@ func TestHandleSubmitBlock_CompactPayloadUsesTemplateCache(t *testing.T) {
 	newTip := makeOutputOnlyTestBlock(tip.Height, tip.PrevHash, genesis.Header.Timestamp+BlockIntervalSec, nil)
 	commitMainChainBlockForTest(t, chain, storage, newTip, chain.TotalWork()+MinDifficulty)
 	chain.mu.Lock()
-	chain.updateTipSnapshotLocked()
+	chain.publishTipLocked()
 	chain.mu.Unlock()
 
 	body, err := json.Marshal(map[string]any{

--- a/api_submitblock_compact_test.go
+++ b/api_submitblock_compact_test.go
@@ -25,7 +25,7 @@ func TestHandleSubmitBlock_CompactPayloadUsesTemplateCache(t *testing.T) {
 			Nonce:    0,
 		},
 	}
-	templateID, err := s.rememberMiningTemplate(template)
+	templateID, _, err := s.rememberMiningTemplateLease(template)
 	if err != nil {
 		t.Fatalf("remember template: %v", err)
 	}

--- a/api_submitblock_compact_test.go
+++ b/api_submitblock_compact_test.go
@@ -9,20 +9,19 @@ import (
 )
 
 func TestHandleSubmitBlock_CompactPayloadUsesTemplateCache(t *testing.T) {
-	chain, _, cleanup := mustCreateTestChain(t)
+	chain, storage, cleanup := mustCreateTestChain(t)
 	defer cleanup()
 	mustAddGenesisBlock(t, chain)
 
 	d := &Daemon{chain: chain}
 	s := NewAPIServer(d, nil, nil, t.TempDir(), nil)
 
-	var wrongPrev [32]byte
-	wrongPrev[0] = 1
+	tip := chain.TemplateParams()
 	template := &Block{
 		Header: BlockHeader{
 			Version:  1,
-			Height:   chain.Height() + 1,
-			PrevHash: wrongPrev,
+			Height:   tip.Height,
+			PrevHash: tip.PrevHash,
 			Nonce:    0,
 		},
 	}
@@ -33,6 +32,18 @@ func TestHandleSubmitBlock_CompactPayloadUsesTemplateCache(t *testing.T) {
 	if templateID == "" {
 		t.Fatal("expected non-empty template id")
 	}
+
+	// Advance the canonical tip after caching so the compact-submit path can
+	// exercise a real stale template without bypassing cache admission rules.
+	genesis := chain.GetBlockByHeight(0)
+	if genesis == nil {
+		t.Fatal("expected genesis block")
+	}
+	newTip := makeOutputOnlyTestBlock(tip.Height, tip.PrevHash, genesis.Header.Timestamp+BlockIntervalSec, nil)
+	commitMainChainBlockForTest(t, chain, storage, newTip, chain.TotalWork()+MinDifficulty)
+	chain.mu.Lock()
+	chain.updateTipSnapshotLocked()
+	chain.mu.Unlock()
 
 	body, err := json.Marshal(map[string]any{
 		"template_id": templateID,

--- a/api_template_lease_test.go
+++ b/api_template_lease_test.go
@@ -176,3 +176,101 @@ func TestHandleRenewBlockTemplate_ValidatesTemplateID(t *testing.T) {
 		t.Fatalf("unknown template id: got %d body=%q", rr.Code, rr.Body.String())
 	}
 }
+
+func TestRenewMiningTemplate_RefreshesEvictionRecency(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	now := time.Date(2026, time.July, 10, 17, 0, 0, 0, time.UTC)
+	s := NewAPIServer(&Daemon{chain: chain}, nil, nil, t.TempDir(), nil)
+	s.templateNow = func() time.Time { return now }
+	s.templateTTL = 24 * time.Hour
+
+	tip := chain.TemplateParams()
+	block := &Block{Header: BlockHeader{
+		Version:  1,
+		Height:   tip.Height,
+		PrevHash: tip.PrevHash,
+	}}
+
+	renewedID, _ := s.rememberMiningTemplateLease(block)
+	now = now.Add(time.Second)
+	inactiveID, _ := s.rememberMiningTemplateLease(block)
+	for i := 2; i < maxMiningTemplateCacheEntries; i++ {
+		now = now.Add(time.Second)
+		s.rememberMiningTemplate(block)
+	}
+
+	now = now.Add(time.Second)
+	renewedAt := now
+	renewedExpiry, err := s.renewMiningTemplate(renewedID)
+	if err != nil {
+		t.Fatalf("renew active template: %v", err)
+	}
+
+	// Adding one more template exceeds the cache cap. The inactive template is
+	// now the least recently touched entry; the renewed template must remain
+	// cached for the lease deadline that was just advertised.
+	now = now.Add(time.Second)
+	newID := s.rememberMiningTemplate(block)
+	if len(s.templateCache) != maxMiningTemplateCacheEntries {
+		t.Fatalf("cache size mismatch: got %d want %d", len(s.templateCache), maxMiningTemplateCacheEntries)
+	}
+	if _, ok := s.getMiningTemplate(renewedID); !ok {
+		t.Fatal("actively renewed template was evicted before advertised expiry")
+	}
+	if _, ok := s.getMiningTemplate(inactiveID); ok {
+		t.Fatal("least-recently-touched inactive template was not evicted")
+	}
+	if _, ok := s.getMiningTemplate(newID); !ok {
+		t.Fatal("new template was not retained after cache-pressure eviction")
+	}
+	if !now.Before(renewedExpiry) {
+		t.Fatalf("test advanced past renewed expiry: now=%s expiry=%s", now, renewedExpiry)
+	}
+
+	s.templateMu.Lock()
+	renewed := s.templateCache[renewedID]
+	s.templateMu.Unlock()
+	if !renewed.lastTouchedAt.Equal(renewedAt) {
+		t.Fatalf("renewal recency mismatch: got %s want %s", renewed.lastTouchedAt, renewedAt)
+	}
+}
+
+func TestMiningTemplateLease_AdvertisedUnixMillisIsPruningBoundary(t *testing.T) {
+	// time.Now carries Go's process-local monotonic reading on supported
+	// platforms. Also force a sub-millisecond wall-clock component so this test
+	// covers both forms of precision that cannot be represented on the wire.
+	rawNow := time.Now()
+	subMillisecond := time.Duration(rawNow.Nanosecond() % int(time.Millisecond))
+	rawNow = rawNow.Add(137*time.Microsecond - subMillisecond)
+
+	s := &APIServer{
+		templateCache: make(map[string]cachedMiningTemplate),
+		templateNow:   func() time.Time { return rawNow },
+		templateTTL:   1500 * time.Millisecond,
+	}
+	normalized := s.miningTemplateNow()
+	if normalized != normalized.Round(0) {
+		t.Fatal("mining-template clock retained a monotonic component")
+	}
+	if got := normalized.UnixNano() % int64(time.Millisecond); got != 0 {
+		t.Fatalf("mining-template clock retained sub-millisecond precision: %d ns", got)
+	}
+
+	templateID, expiry := s.rememberMiningTemplateLease(&Block{})
+	advertisedExpiryMillis := expiry.UnixMilli()
+	if expiry.UnixNano() != advertisedExpiryMillis*int64(time.Millisecond) {
+		t.Fatalf("stored expiry differs from advertised millisecond: stored=%s advertised=%d", expiry, advertisedExpiryMillis)
+	}
+
+	rawNow = time.UnixMilli(advertisedExpiryMillis - 1)
+	if _, ok := s.getMiningTemplate(templateID); !ok {
+		t.Fatal("template pruned before advertised expiry")
+	}
+	rawNow = time.UnixMilli(advertisedExpiryMillis)
+	if _, ok := s.getMiningTemplate(templateID); ok {
+		t.Fatal("template remained cached at advertised expiry")
+	}
+}

--- a/api_template_lease_test.go
+++ b/api_template_lease_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -181,6 +182,36 @@ func TestHandleRenewBlockTemplate_ValidatesTemplateID(t *testing.T) {
 	rr, resp = requestTemplateRenewal(t, handler, "template-lease-token", "missing-template")
 	if rr.Code != http.StatusNotFound || resp.Error != "unknown or expired template_id" {
 		t.Fatalf("unknown template id: got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestRenewMiningTemplate_WithoutChainStateReturnsError(t *testing.T) {
+	s := NewAPIServer(nil, nil, nil, t.TempDir(), nil)
+	s.templateCache["template"] = cachedMiningTemplate{
+		expiresAt: time.Now().Add(time.Minute),
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("renew panicked without chain state: %v", recovered)
+		}
+	}()
+	if _, err := s.renewMiningTemplate("template"); err == nil || !strings.Contains(err.Error(), "without chain state") {
+		t.Fatalf("renew without chain state returned %v", err)
+	}
+}
+
+func TestEarliestMiningTemplateRetryAfterRoundsUp(t *testing.T) {
+	now := time.Date(2026, time.July, 10, 16, 30, 0, 0, time.UTC)
+	cache := map[string]cachedMiningTemplate{
+		"later": {expiresAt: now.Add(10 * time.Second)},
+		"first": {expiresAt: now.Add(1500 * time.Millisecond)},
+	}
+	if got := earliestMiningTemplateRetryAfterSeconds(cache, now); got != 2 {
+		t.Fatalf("Retry-After mismatch: got %d want 2", got)
+	}
+	if got := earliestMiningTemplateRetryAfterSeconds(nil, now); got != 1 {
+		t.Fatalf("empty-cache Retry-After mismatch: got %d want 1", got)
 	}
 }
 

--- a/api_template_lease_test.go
+++ b/api_template_lease_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -56,11 +57,14 @@ func TestHandleRenewBlockTemplate_ExtendsLeaseAcrossLongMiningRound(t *testing.T
 	s.templateTTL = time.Minute
 
 	tip := chain.TemplateParams()
-	templateID, initialExpiry := s.rememberMiningTemplateLease(&Block{Header: BlockHeader{
+	templateID, initialExpiry, err := s.rememberMiningTemplateLease(&Block{Header: BlockHeader{
 		Version:  1,
 		Height:   tip.Height,
 		PrevHash: tip.PrevHash,
 	}})
+	if err != nil {
+		t.Fatalf("remember template: %v", err)
+	}
 	if want := now.Add(time.Minute); !initialExpiry.Equal(want) {
 		t.Fatalf("initial expiry mismatch: got %s want %s", initialExpiry, want)
 	}
@@ -118,11 +122,14 @@ func TestHandleRenewBlockTemplate_RefusesTemplateAfterCanonicalTipChanges(t *tes
 	s.templateTTL = time.Minute
 
 	tip := chain.TemplateParams()
-	templateID, initialExpiry := s.rememberMiningTemplateLease(&Block{Header: BlockHeader{
+	templateID, initialExpiry, err := s.rememberMiningTemplateLease(&Block{Header: BlockHeader{
 		Version:  1,
 		Height:   tip.Height,
 		PrevHash: tip.PrevHash,
 	}})
+	if err != nil {
+		t.Fatalf("remember template: %v", err)
+	}
 
 	genesis := chain.GetBlockByHeight(0)
 	if genesis == nil {
@@ -177,7 +184,7 @@ func TestHandleRenewBlockTemplate_ValidatesTemplateID(t *testing.T) {
 	}
 }
 
-func TestRenewMiningTemplate_RefreshesEvictionRecency(t *testing.T) {
+func TestRememberMiningTemplateLease_RejectsSustainedSameTipChurnWithoutEviction(t *testing.T) {
 	chain, _, cleanup := mustCreateTestChain(t)
 	defer cleanup()
 	mustAddGenesisBlock(t, chain)
@@ -185,7 +192,7 @@ func TestRenewMiningTemplate_RefreshesEvictionRecency(t *testing.T) {
 	now := time.Date(2026, time.July, 10, 17, 0, 0, 0, time.UTC)
 	s := NewAPIServer(&Daemon{chain: chain}, nil, nil, t.TempDir(), nil)
 	s.templateNow = func() time.Time { return now }
-	s.templateTTL = 24 * time.Hour
+	s.templateTTL = time.Hour
 
 	tip := chain.TemplateParams()
 	block := &Block{Header: BlockHeader{
@@ -194,47 +201,123 @@ func TestRenewMiningTemplate_RefreshesEvictionRecency(t *testing.T) {
 		PrevHash: tip.PrevHash,
 	}}
 
-	renewedID, _ := s.rememberMiningTemplateLease(block)
-	now = now.Add(time.Second)
-	inactiveID, _ := s.rememberMiningTemplateLease(block)
-	for i := 2; i < maxMiningTemplateCacheEntries; i++ {
-		now = now.Add(time.Second)
-		s.rememberMiningTemplate(block)
+	ids := make([]string, 0, maxMiningTemplateCacheEntries)
+	var advertisedExpiry time.Time
+	for i := 0; i < maxMiningTemplateCacheEntries; i++ {
+		templateID, expiry, err := s.rememberMiningTemplateLease(block)
+		if err != nil {
+			t.Fatalf("fill cache at entry %d: %v", i, err)
+		}
+		ids = append(ids, templateID)
+		advertisedExpiry = expiry
 	}
-
-	now = now.Add(time.Second)
-	renewedAt := now
-	renewedExpiry, err := s.renewMiningTemplate(renewedID)
+	now = now.Add(30 * time.Minute)
+	renewedExpiry, err := s.renewMiningTemplate(ids[0])
 	if err != nil {
-		t.Fatalf("renew active template: %v", err)
+		t.Fatalf("renew template in full cache: %v", err)
+	}
+	if !renewedExpiry.After(advertisedExpiry) {
+		t.Fatalf("renewal did not extend expiry: got %s initial %s", renewedExpiry, advertisedExpiry)
 	}
 
-	// Adding one more template exceeds the cache cap. The inactive template is
-	// now the least recently touched entry; the renewed template must remain
-	// cached for the lease deadline that was just advertised.
-	now = now.Add(time.Second)
-	newID := s.rememberMiningTemplate(block)
+	// Sustained same-tip churn must fail closed rather than silently evicting any
+	// lease whose expiry has already been advertised to a miner.
+	for i := 0; i < 2*maxMiningTemplateCacheEntries; i++ {
+		now = now.Add(time.Millisecond)
+		templateID, expiry, err := s.rememberMiningTemplateLease(block)
+		if !errors.Is(err, errMiningTemplateCacheFull) {
+			t.Fatalf("overflow attempt %d: got err %v, want cache-full", i, err)
+		}
+		if templateID != "" || !expiry.IsZero() {
+			t.Fatalf("overflow attempt %d returned a lease: id=%q expiry=%s", i, templateID, expiry)
+		}
+	}
 	if len(s.templateCache) != maxMiningTemplateCacheEntries {
-		t.Fatalf("cache size mismatch: got %d want %d", len(s.templateCache), maxMiningTemplateCacheEntries)
+		t.Fatalf("cache grew past bound: got %d want %d", len(s.templateCache), maxMiningTemplateCacheEntries)
 	}
-	if _, ok := s.getMiningTemplate(renewedID); !ok {
-		t.Fatal("actively renewed template was evicted before advertised expiry")
+	for i, templateID := range ids {
+		if _, ok := s.getMiningTemplate(templateID); !ok {
+			t.Fatalf("advertised lease %d was evicted by same-tip churn", i)
+		}
 	}
-	if _, ok := s.getMiningTemplate(inactiveID); ok {
-		t.Fatal("least-recently-touched inactive template was not evicted")
+
+	// Once the inactive leases reach their advertised boundary, insertion prunes
+	// them and capacity becomes available. The actively renewed lease remains.
+	now = advertisedExpiry
+	newID, _, err := s.rememberMiningTemplateLease(block)
+	if err != nil {
+		t.Fatalf("remember template after expiry: %v", err)
+	}
+	if len(s.templateCache) != 2 {
+		t.Fatalf("expired cache was not reclaimed: got %d entries", len(s.templateCache))
+	}
+	if _, ok := s.getMiningTemplate(ids[0]); !ok {
+		t.Fatal("renewed lease was pruned at the inactive leases' expiry")
+	}
+	if _, ok := s.getMiningTemplate(ids[1]); ok {
+		t.Fatal("inactive lease remained after its advertised expiry")
 	}
 	if _, ok := s.getMiningTemplate(newID); !ok {
-		t.Fatal("new template was not retained after cache-pressure eviction")
+		t.Fatal("new template missing after expired leases were pruned")
 	}
-	if !now.Before(renewedExpiry) {
-		t.Fatalf("test advanced past renewed expiry: now=%s expiry=%s", now, renewedExpiry)
+}
+
+func TestRememberMiningTemplateLease_TipChangePrunesOldCapacity(t *testing.T) {
+	chain, storage, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	now := time.Date(2026, time.July, 10, 18, 0, 0, 0, time.UTC)
+	s := NewAPIServer(&Daemon{chain: chain}, nil, nil, t.TempDir(), nil)
+	s.templateNow = func() time.Time { return now }
+	s.templateTTL = time.Hour
+
+	oldTip := chain.TemplateParams()
+	oldBlock := &Block{Header: BlockHeader{Version: 1, Height: oldTip.Height, PrevHash: oldTip.PrevHash}}
+	oldIDs := make([]string, 0, maxMiningTemplateCacheEntries)
+	for i := 0; i < maxMiningTemplateCacheEntries; i++ {
+		templateID, _, err := s.rememberMiningTemplateLease(oldBlock)
+		if err != nil {
+			t.Fatalf("fill old-tip cache at entry %d: %v", i, err)
+		}
+		oldIDs = append(oldIDs, templateID)
 	}
 
-	s.templateMu.Lock()
-	renewed := s.templateCache[renewedID]
-	s.templateMu.Unlock()
-	if !renewed.lastTouchedAt.Equal(renewedAt) {
-		t.Fatalf("renewal recency mismatch: got %s want %s", renewed.lastTouchedAt, renewedAt)
+	genesis := chain.GetBlockByHeight(0)
+	if genesis == nil {
+		t.Fatal("expected genesis block")
+	}
+	newTipBlock := makeOutputOnlyTestBlock(oldTip.Height, oldTip.PrevHash, genesis.Header.Timestamp+BlockIntervalSec, nil)
+	commitMainChainBlockForTest(t, chain, storage, newTipBlock, chain.TotalWork()+MinDifficulty)
+	chain.mu.Lock()
+	chain.updateTipSnapshotLocked()
+	chain.mu.Unlock()
+
+	newTip := chain.TemplateParams()
+	newBlock := &Block{Header: BlockHeader{Version: 1, Height: newTip.Height, PrevHash: newTip.PrevHash}}
+	newID, _, err := s.rememberMiningTemplateLease(newBlock)
+	if err != nil {
+		t.Fatalf("remember first new-tip template: %v", err)
+	}
+	if len(s.templateCache) != 1 {
+		t.Fatalf("tip change did not reclaim old capacity: got %d entries", len(s.templateCache))
+	}
+	for i, templateID := range oldIDs {
+		if _, ok := s.getMiningTemplate(templateID); ok {
+			t.Fatalf("old-tip lease %d survived new-tip insertion", i)
+		}
+	}
+	if _, ok := s.getMiningTemplate(newID); !ok {
+		t.Fatal("new-tip template missing after old-tip pruning")
+	}
+
+	for i := 1; i < maxMiningTemplateCacheEntries; i++ {
+		if _, _, err := s.rememberMiningTemplateLease(newBlock); err != nil {
+			t.Fatalf("fill new-tip cache at entry %d: %v", i, err)
+		}
+	}
+	if _, _, err := s.rememberMiningTemplateLease(newBlock); !errors.Is(err, errMiningTemplateCacheFull) {
+		t.Fatalf("new-tip cache did not enforce bound: got %v", err)
 	}
 }
 
@@ -259,7 +342,10 @@ func TestMiningTemplateLease_AdvertisedUnixMillisIsPruningBoundary(t *testing.T)
 		t.Fatalf("mining-template clock retained sub-millisecond precision: %d ns", got)
 	}
 
-	templateID, expiry := s.rememberMiningTemplateLease(&Block{})
+	templateID, expiry, err := s.rememberMiningTemplateLease(&Block{})
+	if err != nil {
+		t.Fatalf("remember template: %v", err)
+	}
 	advertisedExpiryMillis := expiry.UnixMilli()
 	if expiry.UnixNano() != advertisedExpiryMillis*int64(time.Millisecond) {
 		t.Fatalf("stored expiry differs from advertised millisecond: stored=%s advertised=%d", expiry, advertisedExpiryMillis)

--- a/api_template_lease_test.go
+++ b/api_template_lease_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type renewTemplateTestResponse struct {
+	TemplateID                  string `json:"template_id"`
+	TemplateExpiresAtUnixMillis int64  `json:"template_expires_at_unix_ms"`
+	Error                       string `json:"error"`
+}
+
+func requestTemplateRenewal(t *testing.T, handler http.Handler, token, templateID string) (*httptest.ResponseRecorder, renewTemplateTestResponse) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{"template_id": templateID})
+	if err != nil {
+		t.Fatalf("marshal renewal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/mining/renewtemplate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var resp renewTemplateTestResponse
+	if rr.Body.Len() > 0 && rr.Header().Get("Content-Type") == "application/json" {
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode renewal response: %v (body=%q)", err, rr.Body.String())
+		}
+	}
+	return rr, resp
+}
+
+func authenticatedMiningHandler(s *APIServer, token string) http.Handler {
+	mux := http.NewServeMux()
+	s.registerPrivateRoutes(mux)
+	return authMiddleware(token, mux)
+}
+
+func TestHandleRenewBlockTemplate_ExtendsLeaseAcrossLongMiningRound(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	now := time.Date(2026, time.July, 10, 15, 0, 0, 0, time.UTC)
+	s := NewAPIServer(&Daemon{chain: chain}, nil, nil, t.TempDir(), nil)
+	s.templateNow = func() time.Time { return now }
+	s.templateTTL = time.Minute
+
+	tip := chain.TemplateParams()
+	templateID, initialExpiry := s.rememberMiningTemplateLease(&Block{Header: BlockHeader{
+		Version:  1,
+		Height:   tip.Height,
+		PrevHash: tip.PrevHash,
+	}})
+	if want := now.Add(time.Minute); !initialExpiry.Equal(want) {
+		t.Fatalf("initial expiry mismatch: got %s want %s", initialExpiry, want)
+	}
+
+	const token = "template-lease-token"
+	handler := authenticatedMiningHandler(s, token)
+
+	unauthorized, _ := requestTemplateRenewal(t, handler, "", templateID)
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("renewal route must require bearer auth: got %d body=%q", unauthorized.Code, unauthorized.Body.String())
+	}
+
+	// Renew shortly before each expiry. The total simulated mining round exceeds
+	// the original lease several times without changing the template itself.
+	for i := 0; i < 4; i++ {
+		now = now.Add(50 * time.Second)
+		rr, resp := requestTemplateRenewal(t, handler, token, templateID)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("renewal %d: got %d body=%q", i+1, rr.Code, rr.Body.String())
+		}
+		if resp.TemplateID != templateID {
+			t.Fatalf("renewal %d template id mismatch: got %q want %q", i+1, resp.TemplateID, templateID)
+		}
+		if want := now.Add(time.Minute).UnixMilli(); resp.TemplateExpiresAtUnixMillis != want {
+			t.Fatalf("renewal %d expiry mismatch: got %d want %d", i+1, resp.TemplateExpiresAtUnixMillis, want)
+		}
+		if _, ok := s.getMiningTemplate(templateID); !ok {
+			t.Fatalf("renewal %d did not keep compact-submit template available", i+1)
+		}
+	}
+
+	// At the exact renewed expiry instant the lease is no longer renewable or
+	// available to the existing compact submit path.
+	now = now.Add(time.Minute)
+	rr, resp := requestTemplateRenewal(t, handler, token, templateID)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expired renewal: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if resp.Error != "unknown or expired template_id" {
+		t.Fatalf("expired renewal error mismatch: got %q", resp.Error)
+	}
+	if _, ok := s.getMiningTemplate(templateID); ok {
+		t.Fatal("expired template remained available for compact submission")
+	}
+}
+
+func TestHandleRenewBlockTemplate_RefusesTemplateAfterCanonicalTipChanges(t *testing.T) {
+	chain, storage, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	now := time.Date(2026, time.July, 10, 16, 0, 0, 0, time.UTC)
+	s := NewAPIServer(&Daemon{chain: chain}, nil, nil, t.TempDir(), nil)
+	s.templateNow = func() time.Time { return now }
+	s.templateTTL = time.Minute
+
+	tip := chain.TemplateParams()
+	templateID, initialExpiry := s.rememberMiningTemplateLease(&Block{Header: BlockHeader{
+		Version:  1,
+		Height:   tip.Height,
+		PrevHash: tip.PrevHash,
+	}})
+
+	genesis := chain.GetBlockByHeight(0)
+	if genesis == nil {
+		t.Fatal("expected genesis block")
+	}
+	newTip := makeOutputOnlyTestBlock(tip.Height, tip.PrevHash, genesis.Header.Timestamp+BlockIntervalSec, nil)
+	commitMainChainBlockForTest(t, chain, storage, newTip, chain.TotalWork()+MinDifficulty)
+	chain.mu.Lock()
+	chain.updateTipSnapshotLocked()
+	chain.mu.Unlock()
+
+	now = now.Add(10 * time.Second)
+	handler := authenticatedMiningHandler(s, "template-lease-token")
+	rr, resp := requestTemplateRenewal(t, handler, "template-lease-token", templateID)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("stale-tip renewal: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if resp.Error != "template no longer builds on current tip" {
+		t.Fatalf("stale-tip renewal error mismatch: got %q", resp.Error)
+	}
+
+	// Refusing renewal must not change existing submit semantics: the cached
+	// template remains addressable until its original lease expires, so the
+	// existing submitblock path can apply its normal stale-block rejection.
+	s.templateMu.Lock()
+	cached := s.templateCache[templateID]
+	s.templateMu.Unlock()
+	if !cached.expiresAt.Equal(initialExpiry) {
+		t.Fatalf("stale-tip refusal extended lease: got %s want %s", cached.expiresAt, initialExpiry)
+	}
+	if _, ok := s.getMiningTemplate(templateID); !ok {
+		t.Fatal("stale-tip refusal removed template from existing compact-submit cache")
+	}
+}
+
+func TestHandleRenewBlockTemplate_ValidatesTemplateID(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	s := NewAPIServer(&Daemon{chain: chain}, nil, nil, t.TempDir(), nil)
+	handler := authenticatedMiningHandler(s, "template-lease-token")
+
+	rr, resp := requestTemplateRenewal(t, handler, "template-lease-token", "   ")
+	if rr.Code != http.StatusBadRequest || resp.Error != "template_id is required" {
+		t.Fatalf("blank template id: got %d body=%q", rr.Code, rr.Body.String())
+	}
+
+	rr, resp = requestTemplateRenewal(t, handler, "template-lease-token", "missing-template")
+	if rr.Code != http.StatusNotFound || resp.Error != "unknown or expired template_id" {
+		t.Fatalf("unknown template id: got %d body=%q", rr.Code, rr.Body.String())
+	}
+}

--- a/api_template_lease_test.go
+++ b/api_template_lease_test.go
@@ -321,7 +321,71 @@ func TestRememberMiningTemplateLease_TipChangePrunesOldCapacity(t *testing.T) {
 	}
 }
 
+func TestRememberMiningTemplateLease_RejectsOldInflightTemplateWithoutPurgingNewTip(t *testing.T) {
+	chain, storage, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
+	now := time.Date(2026, time.July, 10, 20, 0, 0, 0, time.UTC)
+	s := NewAPIServer(&Daemon{chain: chain}, nil, nil, t.TempDir(), nil)
+	s.templateNow = func() time.Time { return now }
+	s.templateTTL = time.Hour
+
+	// Simulate request A taking its build snapshot and then stalling before it
+	// reaches cache admission.
+	tipA := chain.TemplateParams()
+	templateA := &Block{Header: BlockHeader{Version: 1, Height: tipA.Height, PrevHash: tipA.PrevHash}}
+
+	genesis := chain.GetBlockByHeight(0)
+	if genesis == nil {
+		t.Fatal("expected genesis block")
+	}
+	tipBBlock := makeOutputOnlyTestBlock(tipA.Height, tipA.PrevHash, genesis.Header.Timestamp+BlockIntervalSec, nil)
+	commitMainChainBlockForTest(t, chain, storage, tipBBlock, chain.TotalWork()+MinDifficulty)
+	chain.mu.Lock()
+	chain.updateTipSnapshotLocked()
+	chain.mu.Unlock()
+
+	// Request B completes first and advertises leases for the new canonical tip.
+	tipB := chain.TemplateParams()
+	templateB := &Block{Header: BlockHeader{Version: 1, Height: tipB.Height, PrevHash: tipB.PrevHash}}
+	bIDs := make([]string, 4)
+	for i := range bIDs {
+		templateID, _, err := s.rememberMiningTemplateLease(templateB)
+		if err != nil {
+			t.Fatalf("remember tip-B template %d: %v", i, err)
+		}
+		bIDs[i] = templateID
+	}
+
+	// Request A now completes out of order. Cache admission must compare it to
+	// canonical tip B before pruning, reject it, and leave every B lease intact.
+	templateID, expiry, err := s.rememberMiningTemplateLease(templateA)
+	if !errors.Is(err, errMiningTemplateStale) {
+		t.Fatalf("old in-flight template: got err %v, want stale", err)
+	}
+	if templateID != "" || !expiry.IsZero() {
+		t.Fatalf("stale in-flight request returned a lease: id=%q expiry=%s", templateID, expiry)
+	}
+	if len(s.templateCache) != len(bIDs) {
+		t.Fatalf("stale in-flight request changed cache size: got %d want %d", len(s.templateCache), len(bIDs))
+	}
+	for i, id := range bIDs {
+		cached, ok := s.getMiningTemplate(id)
+		if !ok {
+			t.Fatalf("tip-B lease %d was purged by stale request A", i)
+		}
+		if cached.Header.Height != tipB.Height || cached.Header.PrevHash != tipB.PrevHash {
+			t.Fatalf("tip-B lease %d changed to stale tip A", i)
+		}
+	}
+}
+
 func TestMiningTemplateLease_AdvertisedUnixMillisIsPruningBoundary(t *testing.T) {
+	chain, _, cleanup := mustCreateTestChain(t)
+	defer cleanup()
+	mustAddGenesisBlock(t, chain)
+
 	// time.Now carries Go's process-local monotonic reading on supported
 	// platforms. Also force a sub-millisecond wall-clock component so this test
 	// covers both forms of precision that cannot be represented on the wire.
@@ -330,6 +394,7 @@ func TestMiningTemplateLease_AdvertisedUnixMillisIsPruningBoundary(t *testing.T)
 	rawNow = rawNow.Add(137*time.Microsecond - subMillisecond)
 
 	s := &APIServer{
+		daemon:        &Daemon{chain: chain},
 		templateCache: make(map[string]cachedMiningTemplate),
 		templateNow:   func() time.Time { return rawNow },
 		templateTTL:   1500 * time.Millisecond,
@@ -342,7 +407,11 @@ func TestMiningTemplateLease_AdvertisedUnixMillisIsPruningBoundary(t *testing.T)
 		t.Fatalf("mining-template clock retained sub-millisecond precision: %d ns", got)
 	}
 
-	templateID, expiry, err := s.rememberMiningTemplateLease(&Block{})
+	tip := chain.TemplateParams()
+	templateID, expiry, err := s.rememberMiningTemplateLease(&Block{Header: BlockHeader{
+		Height:   tip.Height,
+		PrevHash: tip.PrevHash,
+	}})
 	if err != nil {
 		t.Fatalf("remember template: %v", err)
 	}

--- a/api_template_lease_test.go
+++ b/api_template_lease_test.go
@@ -138,7 +138,7 @@ func TestHandleRenewBlockTemplate_RefusesTemplateAfterCanonicalTipChanges(t *tes
 	newTip := makeOutputOnlyTestBlock(tip.Height, tip.PrevHash, genesis.Header.Timestamp+BlockIntervalSec, nil)
 	commitMainChainBlockForTest(t, chain, storage, newTip, chain.TotalWork()+MinDifficulty)
 	chain.mu.Lock()
-	chain.updateTipSnapshotLocked()
+	chain.publishTipLocked()
 	chain.mu.Unlock()
 
 	now = now.Add(10 * time.Second)
@@ -290,7 +290,7 @@ func TestRememberMiningTemplateLease_TipChangePrunesOldCapacity(t *testing.T) {
 	newTipBlock := makeOutputOnlyTestBlock(oldTip.Height, oldTip.PrevHash, genesis.Header.Timestamp+BlockIntervalSec, nil)
 	commitMainChainBlockForTest(t, chain, storage, newTipBlock, chain.TotalWork()+MinDifficulty)
 	chain.mu.Lock()
-	chain.updateTipSnapshotLocked()
+	chain.publishTipLocked()
 	chain.mu.Unlock()
 
 	newTip := chain.TemplateParams()
@@ -343,7 +343,7 @@ func TestRememberMiningTemplateLease_RejectsOldInflightTemplateWithoutPurgingNew
 	tipBBlock := makeOutputOnlyTestBlock(tipA.Height, tipA.PrevHash, genesis.Header.Timestamp+BlockIntervalSec, nil)
 	commitMainChainBlockForTest(t, chain, storage, tipBBlock, chain.TotalWork()+MinDifficulty)
 	chain.mu.Lock()
-	chain.updateTipSnapshotLocked()
+	chain.publishTipLocked()
 	chain.mu.Unlock()
 
 	// Request B completes first and advertises leases for the new canonical tip.

--- a/api_template_lease_test.go
+++ b/api_template_lease_test.go
@@ -429,3 +429,92 @@ func TestMiningTemplateLease_AdvertisedUnixMillisIsPruningBoundary(t *testing.T)
 		t.Fatal("template remained cached at advertised expiry")
 	}
 }
+
+func TestMiningTemplateLease_ContentionSamplesClockInsideCacheLock(t *testing.T) {
+	type operationResult struct {
+		templateID string
+		expiresAt  time.Time
+		block      *Block
+		ok         bool
+		err        error
+	}
+
+	for _, operation := range []string{"get", "renew", "remember"} {
+		t.Run(operation, func(t *testing.T) {
+			chain, _, cleanup := mustCreateTestChain(t)
+			defer cleanup()
+			mustAddGenesisBlock(t, chain)
+
+			now := time.Date(2026, time.July, 10, 21, 0, 0, 0, time.UTC)
+			s := NewAPIServer(&Daemon{chain: chain}, nil, nil, t.TempDir(), nil)
+			s.templateNow = func() time.Time { return now }
+			s.templateTTL = time.Minute
+			tip := chain.TemplateParams()
+			block := &Block{Header: BlockHeader{Version: 1, Height: tip.Height, PrevHash: tip.PrevHash}}
+			oldID, boundary, err := s.rememberMiningTemplateLease(block)
+			if err != nil {
+				t.Fatalf("remember initial template: %v", err)
+			}
+
+			clockEntered := make(chan struct{})
+			releaseClock := make(chan struct{})
+			s.templateNow = func() time.Time {
+				close(clockEntered)
+				<-releaseClock
+				return boundary
+			}
+			result := make(chan operationResult, 1)
+			go func() {
+				var out operationResult
+				switch operation {
+				case "get":
+					out.block, out.ok = s.getMiningTemplate(oldID)
+				case "renew":
+					out.expiresAt, out.err = s.renewMiningTemplate(oldID)
+				case "remember":
+					out.templateID, out.expiresAt, out.err = s.rememberMiningTemplateLease(block)
+				}
+				result <- out
+			}()
+
+			<-clockEntered
+			// The test clock blocks at the exact advertised deadline. If TryLock
+			// succeeds here, the operation sampled time before serializing with
+			// cache mutations and could act on a stale pre-wait timestamp.
+			clockSampledOutsideLock := s.templateMu.TryLock()
+			if clockSampledOutsideLock {
+				s.templateMu.Unlock()
+			}
+			close(releaseClock)
+			out := <-result
+			s.templateNow = func() time.Time { return boundary }
+
+			if clockSampledOutsideLock {
+				t.Fatal("mining-template clock was sampled before acquiring templateMu")
+			}
+			switch operation {
+			case "get":
+				if out.ok || out.block != nil {
+					t.Fatal("get returned template at advertised expiry under contention")
+				}
+			case "renew":
+				if !errors.Is(out.err, errMiningTemplateUnavailable) || !out.expiresAt.IsZero() {
+					t.Fatalf("renew at advertised expiry: expiry=%s err=%v", out.expiresAt, out.err)
+				}
+			case "remember":
+				if out.err != nil {
+					t.Fatalf("remember after contended expiry: %v", out.err)
+				}
+				if out.templateID == "" || out.templateID == oldID {
+					t.Fatalf("remember returned invalid replacement id %q", out.templateID)
+				}
+				if want := boundary.Add(time.Minute); !out.expiresAt.Equal(want) {
+					t.Fatalf("replacement expiry mismatch: got %s want %s", out.expiresAt, want)
+				}
+				if _, ok := s.getMiningTemplate(oldID); ok {
+					t.Fatal("expired template survived contended replacement")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Advertise an explicit expiry for compact-submission template IDs.
- Add an authenticated `POST /api/mining/renewtemplate` endpoint that extends an unexpired template while it still builds on the canonical tip.
- Preserve all advertised same-tip leases until expiry within the bounded cache; return `503` at capacity instead of silently evicting live work.
- Return an exact `Retry-After` value and stable machine-readable error codes when capacity is exhausted or a template build loses a tip-change race.
- Reject stale in-flight template builds before they can purge newer-tip leases.
- Document the lease contract in OpenAPI and cover expiry boundaries, renewal, capacity pressure, tip changes, compact submission, concurrent clock access, and backpressure metadata.

## Why

Compact submissions use `template_id` plus a nonce. Previously, the daemon removed each template ID ten minutes after creation even if a miner was still working on it. A valid solution found later in a long mining round could therefore be rejected as an unknown or expired template before normal block validation.

The new lease contract lets clients keep a current template submission-capable for the duration of a long round without making the cache unbounded. Existing clients remain compatible and can ignore the added response field; clients that need long-round protection should renew before the advertised expiry.

Rollout note: a legacy client that continuously requests fresh same-tip templates can fill all 512 protected lease slots and receive `503` until a lease expires or the tip changes. The response identifies `mining_template_cache_full` and supplies `Retry-After` so callers can back off without matching prose. Where the client supports both old and new daemons, deploy the renewal-capable client first, then enable daemon leases.

## Validation

- `cargo build --release --manifest-path crypto-rs/Cargo.toml`
- `go test ./...`
- `go vet .`
- `go test -race . -run 'MiningTemplate|BlockTemplate|CompactPayload' -count=1`
- Deployed the corresponding daemon and pool-client changes in production: lease renewal remained current, services stayed stable, shares continued, and the pool submitted blocks successfully across multiple tip changes.
