### PR TITLE
Refresh mining templates when mempool changes

### DIFF
--- a/api_blocktemplate_reward_address_test.go
+++ b/api_blocktemplate_reward_address_test.go
@@ -79,6 +79,9 @@ func TestHandleBlockTemplate_RewardAddressOverrideAlternates(t *testing.T) {
 	}
 
 	api := NewAPIServer(daemon, wA, nil, t.TempDir(), []byte("pw"))
+	daemon.mempool.mu.Lock()
+	daemon.mempool.generation = 42
+	daemon.mempool.mu.Unlock()
 	templateNow := time.Date(2026, time.July, 10, 12, 0, 0, 0, time.UTC)
 	api.templateNow = func() time.Time { return templateNow }
 	api.templateTTL = 90 * time.Second
@@ -111,6 +114,7 @@ func TestHandleBlockTemplate_RewardAddressOverrideAlternates(t *testing.T) {
 		HeaderBase                  string `json:"header_base"`
 		TemplateID                  string `json:"template_id"`
 		TemplateExpiresAtUnixMillis int64  `json:"template_expires_at_unix_ms"`
+		MempoolGeneration           uint64 `json:"mempool_generation"`
 	}
 
 	// Default: pays to wallet A (loaded wallet)
@@ -128,6 +132,9 @@ func TestHandleBlockTemplate_RewardAddressOverrideAlternates(t *testing.T) {
 		}
 		if got.RewardAddressUsed != wA.Address() {
 			t.Fatalf("reward_address_used mismatch: got %q want %q", got.RewardAddressUsed, wA.Address())
+		}
+		if got.MempoolGeneration != 42 {
+			t.Fatalf("mempool_generation mismatch: got %d want 42", got.MempoolGeneration)
 		}
 		if got.TemplateID == "" {
 			t.Fatal("expected non-empty template_id")

--- a/api_handlers.go
+++ b/api_handlers.go
@@ -2440,8 +2440,9 @@ func (s *APIServer) handleBlockTemplate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Get mempool transactions sorted by fee rate
-	txs := s.daemon.Mempool().GetTransactionsForBlock(MaxBlockSize-1000, 1000)
+	// Get mempool transactions sorted by fee rate together with the exact
+	// generation represented by this selection.
+	txs, mempoolGeneration := s.daemon.Mempool().GetTransactionsForBlockSnapshot(MaxBlockSize-1000, 1000)
 
 	// Build transaction list (coinbase first)
 	allTxs := make([]*Transaction, 0, len(txs)+1)
@@ -2495,6 +2496,7 @@ func (s *APIServer) handleBlockTemplate(w http.ResponseWriter, r *http.Request) 
 		"reward_address_used":         rewardAddrUsed,
 		"template_id":                 templateID,
 		"template_expires_at_unix_ms": expiresAt.UnixMilli(),
+		"mempool_generation":          mempoolGeneration,
 	})
 }
 

--- a/api_mining_openapi_contract_test.go
+++ b/api_mining_openapi_contract_test.go
@@ -28,6 +28,9 @@ func TestOpenAPIMiningTemplateLeaseAndCompactSubmitContract(t *testing.T) {
 	if _, ok := blockTemplateProps["template_expires_at_unix_ms"]; !ok {
 		t.Fatal("BlockTemplate schema missing template_expires_at_unix_ms")
 	}
+	if _, ok := blockTemplateProps["mempool_generation"]; !ok {
+		t.Fatal("BlockTemplate schema missing mempool_generation")
+	}
 
 	renewRequest := mustGetMapAny(t, schemas, "RenewBlockTemplateRequest")
 	renewRequestProps := mustGetMapAny(t, renewRequest, "properties")

--- a/api_openapi.json
+++ b/api_openapi.json
@@ -2851,7 +2851,8 @@
                   "header_base": "0100000080370000...",
                   "reward_address_used": "3wZc3y1Qw4eYpZtGJxkqkV6xG9c2oXHqfJjQ6b3sR5hYhJ8tZz1qvJ1mY1a9o7hV4pYwqH7xG5d5d8cJ8p4",
                   "template_id": "7b3d2f4a9d11c8ef",
-                  "template_expires_at_unix_ms": 1738800840000
+                  "template_expires_at_unix_ms": 1738800840000,
+                  "mempool_generation": 17
                 }
               }
             }
@@ -3155,6 +3156,7 @@
           "total_work": { "type": "integer", "description": "Cumulative chain work (sum of difficulties)" },
           "mempool_size": { "type": "integer", "description": "Number of unconfirmed transactions" },
           "mempool_bytes": { "type": "integer", "description": "Total mempool size in bytes" },
+          "mempool_generation": { "type": "integer", "format": "int64", "description": "Monotonic mempool content generation used by mining clients to detect template changes" },
           "syncing": { "type": "boolean", "description": "True if the node is currently syncing blocks from peers" },
           "identity_age": { "type": "string", "description": "Duration since last P2P identity rotation (e.g. \"2h34m12s\")" }
         },
@@ -3166,6 +3168,7 @@
           "total_work": 14208,
           "mempool_size": 3,
           "mempool_bytes": 4821,
+          "mempool_generation": 17,
           "syncing": false,
           "identity_age": "2h34m12s"
         }
@@ -3385,6 +3388,7 @@
         "properties": {
           "count": { "type": "integer", "description": "Number of unconfirmed transactions" },
           "size_bytes": { "type": "integer", "description": "Total serialized size in bytes" },
+          "generation": { "type": "integer", "format": "int64", "description": "Monotonic content generation; changes whenever transactions are added or removed" },
           "min_fee": { "type": "integer", "description": "Lowest fee in the mempool (atomic units, 0 when empty)" },
           "max_fee": { "type": "integer", "description": "Highest fee in the mempool (atomic units, 0 when empty)" },
           "avg_fee": { "type": "number", "description": "Average fee (atomic units, 0 when empty)" }
@@ -3392,6 +3396,7 @@
         "example": {
           "count": 5,
           "size_bytes": 8420,
+          "generation": 17,
           "min_fee": 10000,
           "max_fee": 25000,
           "avg_fee": 14600.0
@@ -4136,9 +4141,14 @@
             "type": "integer",
             "format": "int64",
             "description": "Unix timestamp in milliseconds when the compact-submission lease expires. Renew with POST /api/mining/renewtemplate before this instant to keep using the same template ID."
+          },
+          "mempool_generation": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Exact mempool generation represented by the template transaction selection. Compare with /api/status mempool_generation to detect same-tip content changes."
           }
         },
-        "required": ["block", "target", "header_base", "reward_address_used", "template_id", "template_expires_at_unix_ms"]
+        "required": ["block", "target", "header_base", "reward_address_used", "template_id", "template_expires_at_unix_ms", "mempool_generation"]
       },
       "RenewBlockTemplateRequest": {
         "type": "object",

--- a/daemon.go
+++ b/daemon.go
@@ -1145,33 +1145,36 @@ func (d *Daemon) processTxData(data []byte) error {
 
 // Stats returns daemon statistics
 type DaemonStats struct {
-	PeerID       string `json:"peer_id"`
-	Peers        int    `json:"peers"`
-	ChainHeight  uint64 `json:"chain_height"`
-	BestHash     string `json:"best_hash"`
-	TotalWork    uint64 `json:"total_work"`
-	MempoolSize  int    `json:"mempool_size"`
-	MempoolBytes int    `json:"mempool_bytes"`
-	Syncing      bool   `json:"syncing"`
-	SyncProgress uint64 `json:"sync_progress,omitempty"`
-	SyncTarget   uint64 `json:"sync_target,omitempty"`
-	SyncPercent  string `json:"sync_percent,omitempty"`
-	IdentityAge  string `json:"identity_age"`
+	PeerID            string `json:"peer_id"`
+	Peers             int    `json:"peers"`
+	ChainHeight       uint64 `json:"chain_height"`
+	BestHash          string `json:"best_hash"`
+	TotalWork         uint64 `json:"total_work"`
+	MempoolSize       int    `json:"mempool_size"`
+	MempoolBytes      int    `json:"mempool_bytes"`
+	MempoolGeneration uint64 `json:"mempool_generation"`
+	Syncing           bool   `json:"syncing"`
+	SyncProgress      uint64 `json:"sync_progress,omitempty"`
+	SyncTarget        uint64 `json:"sync_target,omitempty"`
+	SyncPercent       string `json:"sync_percent,omitempty"`
+	IdentityAge       string `json:"identity_age"`
 }
 
 func (d *Daemon) Stats() DaemonStats {
 	height, bestHash, totalWork := d.chain.TipFast()
+	mempoolStats := d.mempool.Stats()
 
 	stats := DaemonStats{
-		PeerID:       d.node.PeerID().String(),
-		Peers:        len(d.node.Peers()),
-		ChainHeight:  height,
-		BestHash:     fmt.Sprintf("%x", bestHash[:8]),
-		TotalWork:    totalWork,
-		MempoolSize:  d.mempool.Size(),
-		MempoolBytes: d.mempool.SizeBytes(),
-		Syncing:      d.syncMgr.IsSyncing(),
-		IdentityAge:  d.node.IdentityAge().Round(time.Second).String(),
+		PeerID:            d.node.PeerID().String(),
+		Peers:             len(d.node.Peers()),
+		ChainHeight:       height,
+		BestHash:          fmt.Sprintf("%x", bestHash[:8]),
+		TotalWork:         totalWork,
+		MempoolSize:       mempoolStats.Count,
+		MempoolBytes:      mempoolStats.SizeBytes,
+		MempoolGeneration: mempoolStats.Generation,
+		Syncing:           d.syncMgr.IsSyncing(),
+		IdentityAge:       d.node.IdentityAge().Round(time.Second).String(),
 	}
 
 	// Add sync progress if syncing

--- a/mempool.go
+++ b/mempool.go
@@ -67,7 +67,8 @@ type Mempool struct {
 	isCanonicalRingMember RingMemberChecker
 
 	// Stats
-	totalSize int // Total bytes in mempool
+	totalSize  int    // Total bytes in mempool
+	generation uint64 // Monotonic content version for mining-template refreshes
 }
 
 // NewMempool creates a new mempool
@@ -151,6 +152,7 @@ func (m *Mempool) AddTransaction(tx *Transaction, txData []byte) error {
 	}
 	heap.Push(&m.priorityQueue, entry)
 	m.totalSize += size
+	m.generation++
 
 	return nil
 }
@@ -193,6 +195,7 @@ func (m *Mempool) removeTxByID(txID [32]byte) {
 		delete(m.txByImage, input.KeyImage)
 	}
 	m.totalSize -= entry.Size
+	m.generation++
 
 	// Remove from priority queue
 	if entry.index >= 0 && entry.index < len(m.priorityQueue) {
@@ -257,6 +260,14 @@ func (m *Mempool) HasKeyImage(keyImage [32]byte) bool {
 
 // GetTransactionsForBlock returns transactions for mining sorted by fee rate.
 func (m *Mempool) GetTransactionsForBlock(maxSize int, maxCount int) []*Transaction {
+	txs, _ := m.GetTransactionsForBlockSnapshot(maxSize, maxCount)
+	return txs
+}
+
+// GetTransactionsForBlockSnapshot returns a mining transaction selection and
+// the exact mempool generation from the same read lock. Callers can attach the
+// generation to a block template without racing a concurrent mempool change.
+func (m *Mempool) GetTransactionsForBlockSnapshot(maxSize int, maxCount int) ([]*Transaction, uint64) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -292,7 +303,7 @@ func (m *Mempool) GetTransactionsForBlock(maxSize int, maxCount int) []*Transact
 
 	}
 
-	return result
+	return result, m.generation
 }
 
 // Size returns the number of transactions in mempool
@@ -313,11 +324,15 @@ func (m *Mempool) SizeBytes() int {
 func (m *Mempool) Clear() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if len(m.txByID) == 0 {
+		return
+	}
 
 	m.txByID = make(map[[32]byte]*MempoolEntry)
 	m.txByImage = make(map[[32]byte][32]byte)
 	m.priorityQueue = make(txPriorityQueue, 0)
 	m.totalSize = 0
+	m.generation++
 }
 
 // RemoveExpired removes transactions that have been in mempool too long
@@ -434,6 +449,7 @@ func (m *Mempool) OnBlockDisconnected(block *Block, txDataMap map[[32]byte][]byt
 			}
 			heap.Push(&m.priorityQueue, entry)
 			m.totalSize += size
+			m.generation++
 		}
 	}
 }
@@ -452,11 +468,12 @@ func (m *Mempool) GetAllTransactionData() [][]byte {
 
 // Stats returns mempool statistics
 type MempoolStats struct {
-	Count     int     `json:"count"`
-	SizeBytes int     `json:"size_bytes"`
-	MinFee    uint64  `json:"min_fee"`
-	MaxFee    uint64  `json:"max_fee"`
-	AvgFee    float64 `json:"avg_fee"`
+	Count      int     `json:"count"`
+	SizeBytes  int     `json:"size_bytes"`
+	Generation uint64  `json:"generation"`
+	MinFee     uint64  `json:"min_fee"`
+	MaxFee     uint64  `json:"max_fee"`
+	AvgFee     float64 `json:"avg_fee"`
 }
 
 func (m *Mempool) Stats() MempoolStats {
@@ -464,8 +481,9 @@ func (m *Mempool) Stats() MempoolStats {
 	defer m.mu.RUnlock()
 
 	stats := MempoolStats{
-		Count:     len(m.txByID),
-		SizeBytes: m.totalSize,
+		Count:      len(m.txByID),
+		SizeBytes:  m.totalSize,
+		Generation: m.generation,
 	}
 
 	if stats.Count == 0 {

--- a/mempool_test.go
+++ b/mempool_test.go
@@ -112,3 +112,53 @@ func TestMempoolRejectsTrailingBytes(t *testing.T) {
 		t.Fatalf("mempool should remain empty, size=%d", got)
 	}
 }
+
+func TestMempoolGenerationTracksContentChanges(t *testing.T) {
+	tx := mustBuildValidRingCTBindingTestTx(t)
+	cfg := DefaultMempoolConfig()
+	cfg.MinFeeRate = 0
+	mempool := NewMempool(
+		cfg,
+		func(_ [32]byte) bool { return false },
+		func(_, _ [32]byte) bool { return true },
+	)
+
+	if got := mempool.Stats().Generation; got != 0 {
+		t.Fatalf("initial generation = %d, want 0", got)
+	}
+	if err := mempool.AddTransaction(tx, tx.Serialize()); err != nil {
+		t.Fatalf("add transaction: %v", err)
+	}
+	if got := mempool.Stats().Generation; got != 1 {
+		t.Fatalf("generation after add = %d, want 1", got)
+	}
+
+	selected, generation := mempool.GetTransactionsForBlockSnapshot(MaxBlockSize, 1000)
+	if len(selected) != 1 || generation != 1 {
+		t.Fatalf("snapshot = (%d txs, generation %d), want (1, 1)", len(selected), generation)
+	}
+
+	// Duplicate delivery is not a content change.
+	if err := mempool.AddTransaction(tx, tx.Serialize()); err != nil {
+		t.Fatalf("add duplicate transaction: %v", err)
+	}
+	if got := mempool.Stats().Generation; got != 1 {
+		t.Fatalf("generation after duplicate = %d, want 1", got)
+	}
+
+	txID, err := tx.TxID()
+	if err != nil {
+		t.Fatalf("transaction id: %v", err)
+	}
+	mempool.RemoveTransaction(txID)
+	if stats := mempool.Stats(); stats.Generation != 2 || stats.Count != 0 {
+		t.Fatalf("stats after removal = %+v, want generation 2 and count 0", stats)
+	}
+
+	// Removing or clearing an already-empty pool must not report a false change.
+	mempool.RemoveTransaction(txID)
+	mempool.Clear()
+	if got := mempool.Stats().Generation; got != 2 {
+		t.Fatalf("generation after no-op removals = %d, want 2", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add a monotonic mempool content generation that advances only on actual additions/removals
- expose the generation through mempool stats and `/api/status`
- attach the exact generation captured with each block template transaction selection
- document the contract in OpenAPI and add regression coverage

## Why

Mining clients commonly cache or renew templates while the chain tip is unchanged. Without a mempool content version, they cannot tell that a same-tip template is missing newly arrived transactions. Capturing the generation under the same read lock as transaction selection avoids a race between selecting transactions and labeling the template.

Client that do not use the new fields continue to work unchanged.